### PR TITLE
Add Job Aggregator project and expand skills

### DIFF
--- a/index.html
+++ b/index.html
@@ -816,6 +816,8 @@
           <span class="chip">RESTful APIs</span>
           <span class="chip">NumPy</span>
           <span class="chip">Pandas</span>
+          <span class="chip">Flask</span>
+          <span class="chip">HTMX</span>
         </div>
       </div>
 
@@ -833,6 +835,7 @@
           <span class="chip">Windows Server</span>
           <span class="chip">Linux</span>
           <span class="chip">Artifactory</span>
+          <span class="chip">Claude API</span>
         </div>
       </div>
 
@@ -916,6 +919,37 @@
             <span class="project-tag">Docker</span>
           </div>
           <a href="https://github.com/cbeaulieu-gt/siege-web" class="project-link" target="_blank"
+            rel="noopener noreferrer">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+              <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577
+                0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.385-1.335-1.755-1.335-1.755
+                -1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305
+                3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38
+                1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23a11.52 11.52 0 0 1 3-.405
+                11.52 11.52 0 0 1 3 .405c2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84
+                1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015
+                2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+            </svg>
+            View on GitHub
+          </a>
+        </article>
+
+        <article class="project-card">
+          <h3 class="project-name">Job Aggregator</h3>
+          <p class="project-desc">
+            A local job search pipeline that fetches listings from the Adzuna API, scores each one against a personal
+            skills profile using Claude AI, and surfaces ranked results in a browser-based feed with bookmark and
+            application tracking.
+          </p>
+          <div class="project-tags">
+            <span class="project-tag">Python</span>
+            <span class="project-tag">Flask</span>
+            <span class="project-tag">SQLite</span>
+            <span class="project-tag">HTMX</span>
+            <span class="project-tag">Anthropic API</span>
+            <span class="project-tag">BeautifulSoup4</span>
+          </div>
+          <a href="https://github.com/cbeaulieu-gt/job_aggregator" class="project-link" target="_blank"
             rel="noopener noreferrer">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
               <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577


### PR DESCRIPTION
## Summary

- Adds a new **Job Aggregator** project card — a local job search pipeline that fetches listings from the Adzuna API, scores them with Claude AI, and surfaces ranked results in a Flask/HTMX web UI
- Adds **Flask** and **HTMX** to the Frameworks & Backend skills group
- Adds **Claude API** to the Tools & Platforms skills group

## Test plan

- [x] Open `index.html` locally and verify the Job Aggregator card renders correctly in the projects grid
- [x] Confirm the GitHub link points to `https://github.com/cbeaulieu-gt/job_aggregator`
- [x] Verify Flask, HTMX, and Claude API chips appear in the Skills section
- [x] Check mobile layout — card grid should stack to single column

🤖 Generated with [Claude Code](https://claude.com/claude-code)