### PR TITLE
feat: job matcher project + mobile nav overhaul

### DIFF
--- a/index.html
+++ b/index.html
@@ -660,13 +660,24 @@
       }
 
       .site-nav ul {
-        gap: 16px;
-        height: 38px;
+        justify-content: flex-start;
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+        gap: 20px;
+        padding: 0 16px;
+        height: auto;
+        min-height: 38px;
+      }
+
+      .site-nav ul::-webkit-scrollbar {
+        display: none;
       }
 
       .site-nav a {
         font-size: 11px;
         letter-spacing: 0.07em;
+        white-space: nowrap;
       }
 
       .hero-links {


### PR DESCRIPTION
## Summary

- Renamed Job Aggregator project to Job Matcher and updated related links
- Added Job Aggregator project card and expanded skills section
- Fixed mobile nav bar overflowing horizontally (closes #3)
- Replaced horizontal-scroll mobile nav with hamburger/drawer menu (closes #5)
- Fixed multiple nav links highlighted simultaneously after tapping (closes #6)

## Mobile Nav Overhaul

### Hamburger menu (closes #5)
Replaced the awkward horizontal-scroll nav with a proper hamburger/drawer pattern on mobile (≤ 600px):
- ☰ button shown on mobile, hidden on desktop — uses a real `<button>` for keyboard focus and ARIA semantics
- Tapping opens a full-width drawer with stacked links (44px tap targets)
- Tapping a link navigates, closes the drawer, and blurs focus
- Closes on outside click or `Escape` key
- `aria-expanded` kept in sync for accessibility

### Multi-highlight bug fix (closes #6)
Rewrote the `IntersectionObserver` scroll-spy:
- Maintains a `Set` of currently-intersecting section IDs — sections are added/removed as they enter/leave
- After each batch, elects a single winner (topmost visible section by `getBoundingClientRect().top`)
- Clears all `nav-active` once, then sets it on exactly one link — no more flicker or double-highlight
- `.blur()` called on click to dismiss the mobile browser focus ring that was overlapping the active state
- Active state kept in sync across both desktop nav links and drawer links

## Test plan
- [ ] Desktop nav looks and behaves unchanged (≥ 601px)
- [ ] Mobile: hamburger button visible, drawer opens/closes correctly
- [ ] Drawer links navigate and close the drawer
- [ ] Outside click and Escape close the drawer
- [ ] Scroll-spy highlights exactly one nav link at a time
- [ ] Tapping a link does not leave a stale highlight
- [ ] Job Matcher project card renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)