### PR TITLE
fix: drawer content hidden due to overly broad CSS selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -722,7 +722,7 @@
         padding: 72px 0 56px;
       }
 
-      .site-nav ul {
+      .site-nav > ul {
         display: none;
       }
 


### PR DESCRIPTION
## Summary

Fixes hamburger drawer content being invisible on mobile (closes #8).

## Root Cause

In `@media (max-width: 600px)`, the rule:

```css
.site-nav ul { display: none; }
```

uses a **descendant** selector — it matched *all* `<ul>` elements inside `.site-nav`, including the one inside `.nav-drawer`. So the drawer's list was permanently hidden regardless of the `hidden` attribute being removed by JS.

## Fix

One-character change: `.site-nav ul` → `.site-nav > ul`

The `>` direct-child combinator scopes the rule to only the top-level desktop nav list, leaving the drawer's inner `<ul>` free to render when the drawer opens.

## Test plan
- [ ] Tap hamburger on mobile — drawer slides open with all 6 links visible
- [ ] Tap a drawer link — navigates to section and closes drawer
- [ ] Desktop nav unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)