### PR TITLE
fix: drawer background transparent due to parent backdrop-filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -561,10 +561,16 @@
     }
 
     /* ── Drawer panel (mobile only) ─────────────────────── */
+    /* position: absolute floats the drawer as its own layer below the nav bar,
+       preventing the parent's backdrop-filter from making the background transparent */
     .nav-drawer {
-      background: var(--bg-surface);
+      position: absolute;
+      top: 100%;
+      left: 0;
+      right: 0;
+      background: var(--bg-base);
       border-bottom: 1px solid var(--border);
-      width: 100%;
+      z-index: 99;
     }
 
     .nav-drawer ul {


### PR DESCRIPTION
## Summary

Fixes hamburger drawer appearing with a transparent background over page content (closes #10).

## Root Cause

The parent `<nav>` has `backdrop-filter: blur(12px)`, which creates a GPU compositing layer. Child elements inside that layer can't paint their backgrounds opaquely over content outside it — making the drawer background appear see-through.

## Fix

Changed `.nav-drawer` to `position: absolute; top: 100%; left: 0; right: 0; z-index: 99` with `background: var(--bg-base)`.

Positioning the drawer absolutely takes it out of normal flow and gives it its own independent rendering layer, where its solid `#0d0d0d` background correctly covers the page content beneath it.

## Test plan
- [ ] Tap hamburger on mobile — drawer opens with a solid dark background
- [ ] Nav links are legible with no page content showing through
- [ ] Tapping a link navigates and closes the drawer
- [ ] Desktop nav unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)