### PR TITLE
fix: move drawer outside nav to escape backdrop-filter compositing layer

### DIFF
--- a/index.html
+++ b/index.html
@@ -561,11 +561,13 @@
     }
 
     /* ── Drawer panel (mobile only) ─────────────────────── */
-    /* position: absolute floats the drawer as its own layer below the nav bar,
-       preventing the parent's backdrop-filter from making the background transparent */
+    /* Drawer is a sibling of <nav>, not a child — this is intentional.
+       A child of a backdrop-filter element is trapped in its compositing layer
+       and cannot paint an opaque background over content below. As a sibling,
+       the drawer renders in its own layer with a fully solid background. */
     .nav-drawer {
-      position: absolute;
-      top: 100%;
+      position: fixed;
+      top: 44px;
       left: 0;
       right: 0;
       background: var(--bg-base);
@@ -767,17 +769,19 @@
       <li><a href="#resume">Resume</a></li>
       <li><a href="#contact">Contact</a></li>
     </ul>
-    <div class="nav-drawer" hidden>
-      <ul>
-        <li><a href="#about">About</a></li>
-        <li><a href="#stack">Skills</a></li>
-        <li><a href="#experience">Experience</a></li>
-        <li><a href="#projects">Projects</a></li>
-        <li><a href="#resume">Resume</a></li>
-        <li><a href="#contact">Contact</a></li>
-      </ul>
-    </div>
   </nav>
+  <!-- Drawer is a sibling of nav (not a child) so it renders outside the
+       nav's backdrop-filter compositing layer and gets a truly opaque background -->
+  <div class="nav-drawer" hidden>
+    <ul>
+      <li><a href="#about">About</a></li>
+      <li><a href="#stack">Skills</a></li>
+      <li><a href="#experience">Experience</a></li>
+      <li><a href="#projects">Projects</a></li>
+      <li><a href="#resume">Resume</a></li>
+      <li><a href="#contact">Contact</a></li>
+    </ul>
+  </div>
 
   <!-- =====================================================
        HERO SECTION


### PR DESCRIPTION
## Summary

Fixes hamburger drawer background still appearing transparent (closes #13).

## Root Cause

`position: absolute` on a child of a `backdrop-filter` element doesn't escape the GPU compositing layer — the child is still rendered inside the blurred layer and cannot paint an opaque background over content outside it. This is a WebKit/Safari limitation that affects any descendant, regardless of positioning.

## Fix

Moved `<div class="nav-drawer">` to be a **sibling** of `<nav>` rather than a child. It now renders in its own independent layer, completely unaffected by the nav's `backdrop-filter`.

CSS updated to `position: fixed; top: 44px` (the nav bar height) so it still floats directly below the nav bar across all browsers.

No JS changes needed — `document.querySelector('.nav-drawer')` finds it correctly regardless of DOM position.

## Test plan
- [ ] Tap hamburger on mobile — drawer opens with a fully opaque dark background
- [ ] No page content visible through the drawer
- [ ] Tapping a link navigates and closes the drawer
- [ ] Desktop nav unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)