### PR TITLE
update: sync Job Matcher project card and skills with actual tech stack

### DIFF
--- a/index.html
+++ b/index.html
@@ -900,6 +900,8 @@
           <span class="chip">Pandas</span>
           <span class="chip">Flask</span>
           <span class="chip">HTMX</span>
+          <span class="chip">Pydantic</span>
+          <span class="chip">BeautifulSoup4</span>
         </div>
       </div>
 
@@ -914,10 +916,13 @@
           <span class="chip">GitLab CI/CD</span>
           <span class="chip">SQL Server</span>
           <span class="chip">PostgreSQL</span>
+          <span class="chip">SQLite</span>
           <span class="chip">Windows Server</span>
           <span class="chip">Linux</span>
           <span class="chip">Artifactory</span>
           <span class="chip">Claude API</span>
+          <span class="chip">OpenAI API</span>
+          <span class="chip">Gemini API</span>
         </div>
       </div>
 
@@ -1019,8 +1024,9 @@
         <article class="project-card">
           <h3 class="project-name">Job Matcher</h3>
           <p class="project-desc">
-            A local job search pipeline that fetches listings from the Adzuna API, scores each one against a personal
-            skills profile using Claude AI, and surfaces ranked results in a browser-based feed with bookmark and
+            A multi-source job search pipeline that aggregates listings from 7 public APIs (Adzuna, RemoteOK,
+            Himalayas, and more), scores each posting against a personal skills profile using a pluggable LLM backend
+            (Claude, GPT-4, or Gemini), and presents ranked results in a Flask/HTMX web UI with bookmark and
             application tracking.
           </p>
           <div class="project-tags">
@@ -1028,7 +1034,8 @@
             <span class="project-tag">Flask</span>
             <span class="project-tag">SQLite</span>
             <span class="project-tag">HTMX</span>
-            <span class="project-tag">Anthropic API</span>
+            <span class="project-tag">Pydantic</span>
+            <span class="project-tag">Multi-LLM</span>
             <span class="project-tag">BeautifulSoup4</span>
           </div>
           <a href="https://github.com/cbeaulieu-gt/job-matcher-ui" class="project-link" target="_blank"


### PR DESCRIPTION
## Summary

Syncs the Job Matcher project card and skills section with what's actually in `cbeaulieu-gt/job-matcher-ui` (closes #15).

## Changes

### Job Matcher project description
- **Before:** Only mentioned Adzuna API and Claude
- **After:** Accurately describes 7 job sources (Adzuna, RemoteOK, Himalayas, and more) and the pluggable multi-LLM backend (Claude, GPT-4, Gemini)

### Job Matcher project tags
- Replaced `Anthropic API` with `Multi-LLM` (more accurate — supports 3 providers)
- Added `Pydantic` (used extensively for data validation throughout the codebase)

### Skills — Frameworks & Backend
- Added `Pydantic`
- Added `BeautifulSoup4`

### Skills — Tools & Platforms
- Added `SQLite` (the project's database, alongside the existing SQL Server and PostgreSQL entries)
- Added `OpenAI API`
- Added `Gemini API`

## Test plan
- [x] Project card description reads accurately
- [x] Tags render correctly in the project card
- [x] New skill chips appear in the correct groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)