### PR TITLE
feat: integrate GoatCounter analytics with on-page visitor count bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ If you want to use this as a template, search `index.html` for `<!-- CUSTOMIZE -
 
 ---
 
+## Analytics
+
+GoatCounter is integrated for cookie-free, privacy-respecting page view tracking. The dashboard is at [cmbdev.goatcounter.com](https://cmbdev.goatcounter.com). No consent banner is required — GoatCounter does not use cookies or collect personal data.
+
+---
+
 ## License
 
 MIT — see [LICENSE](LICENSE).

--- a/index.html
+++ b/index.html
@@ -499,6 +499,14 @@
       color: var(--text-muted);
     }
 
+    .visitor-bar {
+      margin-top: 6px;
+      font-size: 11px;
+      color: var(--text-muted);
+      opacity: 0.6;
+      letter-spacing: 0.02em;
+    }
+
     /* =====================================================
        NAVIGATION
     ===================================================== */
@@ -1138,6 +1146,7 @@
     <div class="container">
       <!-- CUSTOMIZE: Replace "Christopher M. Beaulieu" with your name if needed -->
       <p>&copy; <span id="year"></span> Christopher M. Beaulieu. Built and hosted on GitHub Pages.</p>
+      <p class="visitor-bar">visitors: <span class="goatcounter-count" data-path="/"></span></p>
     </div>
   </footer>
 
@@ -1256,6 +1265,10 @@
       window.scrollTo({ top: 0, behavior: 'smooth' });
     });
   </script>
+
+  <!-- GoatCounter analytics — cookie-free, privacy-respecting page view tracking -->
+  <script data-goatcounter="https://cmbdev.goatcounter.com/count"
+          async src="//gc.zgo.at/count.js"></script>
 
 </body>
 


### PR DESCRIPTION
## Summary
- Embeds the GoatCounter tracking script (`cmbdev.goatcounter.com`) before `</body>` — async, non-blocking, cookie-free
- Adds a slim visitor count bar at the bottom of the footer using GoatCounter's count widget
- Updates README with an Analytics section

## Changes
- `index.html` — tracking script + visitor bar markup + `.visitor-bar` CSS (11px, muted gray, 0.6 opacity — reads as a footnote)
- `README.md` — new `## Analytics` section noting the integration and dashboard URL

## Test plan
- [ ] Open the live site and verify the visitor bar appears at the bottom of the footer
- [ ] Confirm the bar matches the dark color scheme and doesn't disrupt layout
- [ ] Check the GoatCounter dashboard at `cmbdev.goatcounter.com` to confirm a pageview was recorded
- [ ] Verify no cookie consent banner is needed (GoatCounter is cookie-free)

closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)