### PR TITLE
chore: add Prettier, EditorConfig, and style guide

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "singleQuote": false,
+  "htmlWhitespaceSensitivity": "css"
+}

--- a/README.md
+++ b/README.md
@@ -31,6 +31,30 @@ Then visit `http://localhost:8080`.
 
 ---
 
+## Development
+
+**Prerequisites:** [Node.js](https://nodejs.org/) (any LTS version)
+
+Install dev tools once after cloning:
+
+```bash
+npm install
+```
+
+Format `index.html` before committing:
+
+```bash
+npm run format
+```
+
+Verify formatting without writing changes (useful in CI):
+
+```bash
+npm run check
+```
+
+---
+
 ## Customizing
 
 If you want to use this as a template, search `index.html` for `<!-- CUSTOMIZE -->` comments. Each one marks a section with values you should replace — name, title, description, links, project entries, and so on.

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -1,0 +1,78 @@
+# Style Guide
+
+## Formatting
+
+All formatting is handled by [Prettier](https://prettier.io/). Do not manually adjust whitespace, indentation, or quote style — run the formatter before committing instead.
+
+```bash
+npm run format   # format index.html in place
+npm run check    # verify formatting without writing changes
+```
+
+Configuration lives in `.prettierrc`. Editor integration is defined in `.editorconfig`.
+
+---
+
+## CSS conventions
+
+### Custom properties
+
+- Named in `--kebab-case`
+- Declared on `:root` so they are globally available
+- Grouped by category in this order: colors, borders/radii, transitions, typography, layout
+
+Example from the current `:root` block:
+
+```css
+:root {
+  /* Colors */
+  --bg-base: #0d0d0d;
+  --accent: #3dd68c;
+
+  /* Borders & radii */
+  --radius-sm: 6px;
+
+  /* Transitions */
+  --transition: 150ms ease;
+
+  /* Typography */
+  --font-stack: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+
+  /* Layout */
+  --max-width: 860px;
+}
+```
+
+---
+
+## Section comments
+
+CSS sections are delimited by banner comments. Use this exact pattern — do not abbreviate or alter the character count:
+
+```css
+/* =====================================================
+   SECTION NAME
+===================================================== */
+```
+
+The existing sections in order are: `RESET & BASE`, `LAYOUT UTILITIES`, `HERO SECTION`, `NAV`, etc. Add new sections in the same style and place them in a logical reading order.
+
+---
+
+## HTML structure
+
+This is a single-file static site. All markup, styles, and scripts live in `index.html`:
+
+- **CSS** — inline in a `<style>` block inside `<head>`
+- **JavaScript** — inline in a `<script>` block placed immediately before `</body>`
+- **Analytics** — a separate `<script>` tag for GoatCounter follows the main script, also before `</body>`
+
+Do not introduce external `.css` or `.js` files unless there is a clear performance or maintenance reason and the change is discussed first.
+
+---
+
+## How to run the formatter
+
+1. Install dependencies once: `npm install`
+2. Format: `npm run format`
+3. Verify CI will pass: `npm run check`

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "github-profile-page",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "format": "prettier --write index.html",
+    "check": "prettier --check index.html"
+  },
+  "devDependencies": {
+    "prettier": "^3.5.3"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.editorconfig` for editor-level formatting enforcement (no tooling required)
- Adds `package.json` + `.prettierrc` with Prettier as the only dev dependency
- Adds `docs/STYLE_GUIDE.md` documenting CSS conventions, section comment format, and file architecture
- Updates `README.md` with a Development section

## Changes
- `.editorconfig` — 2-space indent, LF line endings, trim trailing whitespace, final newline
- `package.json` — Prettier `^3.5.3`, `npm run format` and `npm run check` scripts
- `.prettierrc` — matches existing code style (100 printWidth, 2 tabWidth, double quotes, `htmlWhitespaceSensitivity: "css"`)
- `docs/STYLE_GUIDE.md` — formatting, CSS custom property conventions, section banner pattern, single-file architecture
- `README.md` — new Development section with setup and format commands

## Test plan
- [ ] `npm install` completes without errors
- [ ] `npm run check` passes on `index.html` without any formatting changes reported
- [ ] `npm run format` runs without error
- [ ] `.editorconfig` rules are picked up by VS Code / editor of choice
- [ ] `docs/STYLE_GUIDE.md` renders correctly on GitHub

closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)