### PR TITLE
chore: add .prettierrc to fix npm run check on Windows

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,6 @@
   "tabWidth": 2,
   "useTabs": false,
   "singleQuote": false,
-  "htmlWhitespaceSensitivity": "css"
+  "htmlWhitespaceSensitivity": "css",
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
## Summary
Adds a single-line `.prettierrc` setting `endOfLine: "auto"` so `npm run check` (which runs `prettier --check index.html`) passes on Windows checkouts where git's `core.autocrlf` puts CRLF line endings on disk.

Closes #33.

## Why
Prettier's default is `endOfLine: "lf"`. On Windows, git's autocrlf converts source files to CRLF on checkout, so prettier flags every line in `index.html` as a whitespace difference. `"auto"` tells prettier to accept whatever the file already uses — the right behavior for a project with no `.gitattributes` enforcement.

## Verification
- Before: `npm run check` exits 1 with "Code style issues found"
- After: `npm run check` exits 0 with "All matched files use Prettier code style!"
- No source files modified — config-only change

## Alternative considered
`.gitattributes` with `*.html text eol=lf` would force LF on disk regardless of OS. Architecturally cleaner but invasive (changes everyone's working copy). Deferred — current single-developer Windows-only setup doesn't need the strictness.

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*