### PR TITLE
chore: ignore .worktrees/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ desktop.ini
 
 # Node modules — in case someone forks and adds tooling
 node_modules/
+
+# Local git worktrees — created via superpowers:using-git-worktrees skill
+.worktrees/


### PR DESCRIPTION
## Summary

Adds `.worktrees/` to `.gitignore` so local git worktrees created via the conventional `.worktrees/<branch-name>` workflow don't show up as untracked in the main checkout.

## Why

The `superpowers:using-git-worktrees` skill (and the project's CLAUDE.md) require this directory be ignored before creating worktrees, to prevent accidental commits of worktree contents via `git add .` from the main checkout. Currently `.worktrees/` shows as untracked in `git status` from main, which is exactly the failure mode the rule is meant to prevent.

## Test plan

- [x] `git check-ignore -q .worktrees/foo` returns 0 after merge
- [x] No source/build files affected — `.gitignore`-only change

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*