### PR TITLE
content: rebrand Siege card to RSL Siege Manager, add live site link

### DIFF
--- a/index.html
+++ b/index.html
@@ -1051,48 +1051,72 @@
 
         <div class="projects-grid">
           <article class="project-card">
-            <h3 class="project-name">Siege Assignment Web App</h3>
+            <h3 class="project-name">RSL Siege Manager</h3>
             <p class="project-desc">
-              A full-stack web app for managing Raid Shadow Legends clan siege assignments. Features
-              a drag-and-drop board with an auto-fill algorithm, a real-time validation engine, PNG
-              battle card generation via Playwright, and Discord DM notifications — deployed to
-              Azure Container Apps behind Azure AD auth.
+              An open-source web app for managing Raid: Shadow Legends clan siege assignments —
+              self-hostable anywhere Docker runs. Features a drag-and-drop assignment board with an
+              auto-fill algorithm, a real-time validation engine, PNG battle card generation via
+              Playwright, and Discord DM notifications. The reference deployment runs on Azure
+              Container Apps behind Azure AD authentication.
             </p>
             <div class="project-tags">
+              <span class="project-tag">Open Source</span>
               <span class="project-tag">FastAPI</span>
               <span class="project-tag">React</span>
+              <span class="project-tag">Vite</span>
               <span class="project-tag">TypeScript</span>
               <span class="project-tag">PostgreSQL</span>
               <span class="project-tag">Docker</span>
               <span class="project-tag">Discord</span>
               <span class="project-tag">Azure</span>
             </div>
-            <a
-              href="https://github.com/cbeaulieu-gt/siege-web"
-              class="project-link"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              <svg
-                width="14"
-                height="14"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                aria-hidden="true"
+            <div style="display: flex; gap: 16px; flex-wrap: wrap">
+              <a
+                href="https://github.com/cbeaulieu-gt/siege-web"
+                class="project-link"
+                target="_blank"
+                rel="noopener noreferrer"
               >
-                <path
-                  d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577
-                0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.385-1.335-1.755-1.335-1.755
-                -1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305
-                3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38
-                1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23a11.52 11.52 0 0 1 3-.405
-                11.52 11.52 0 0 1 3 .405c2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84
-                1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015
-                2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"
-                />
-              </svg>
-              View on GitHub
-            </a>
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577
+                  0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.385-1.335-1.755-1.335-1.755
+                  -1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305
+                  3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38
+                  1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23a11.52 11.52 0 0 1 3-.405
+                  11.52 11.52 0 0 1 3 .405c2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84
+                  1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015
+                  2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"
+                  />
+                </svg>
+                View on GitHub
+              </a>
+              <a
+                href="https://rslsiege.com"
+                class="project-link"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zm-1 17.93V18a1 1 0 0 1 2 0v1.93A8.001 8.001 0 0 1 4.07 13H6a1 1 0 0 1 0 2H4.07A8.001 8.001 0 0 1 11 19.93zM12 8a4 4 0 1 0 0 8 4 4 0 0 0 0-8z"
+                  />
+                </svg>
+                Live
+              </a>
+            </div>
           </article>
 
           <article class="project-card">


### PR DESCRIPTION
## Summary

- Card title rebranded from \"Siege Assignment Web App\" to \"RSL Siege Manager\"
- Description rewritten to lead with open-source/self-hostable positioning; restored colon in \"Raid: Shadow Legends\"; Azure softened to a \"reference deployment\"
- Added Live link to https://rslsiege.com using the same dual-link pattern (flex wrapper + globe SVG) as the Job Matcher card
- Added \"Open Source\" and \"Vite\" tags to the tag list

closes #35

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*