### PR TITLE
content: correct Siege auth provider — Discord, not Azure AD

### DIFF
--- a/index.html
+++ b/index.html
@@ -1057,7 +1057,7 @@
               self-hostable anywhere Docker runs. Features a drag-and-drop assignment board with an
               auto-fill algorithm, a real-time validation engine, PNG battle card generation via
               Playwright, and Discord DM notifications. The reference deployment runs on Azure
-              Container Apps behind Azure AD authentication.
+              Container Apps behind Discord authentication.
             </p>
             <div class="project-tags">
               <span class="project-tag">Open Source</span>


### PR DESCRIPTION
## Summary

Single-line content fix to the Siege project card on the portfolio page. The reference deployment authenticates users via **Discord OAuth**, not Azure AD.

## Why

Caught after PR #37 merged. The original rebrand description said "behind Azure AD authentication" — that's incorrect; the Siege app uses Discord auth (which also explains the Discord DM notifications mentioned in the same description).

## Diff

`index.html` line 1060:
- **Before**: `Container Apps behind Azure AD authentication.`
- **After**: `Container Apps behind Discord authentication.`

## Test plan

- [x] `npm run check` — prettier passes (verified locally)
- [x] No other content or markup changes

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*