### PR TITLE
content: drop middle initial from LICENSE copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Christopher M. Beaulieu
+Copyright (c) 2026 Christopher Beaulieu
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

- Removes the middle initial from the MIT License copyright line, normalizing the name to "Christopher Beaulieu" across the entire repo
- The README and OG image were updated in PR #32 (closes #31), but LICENSE was explicitly out of scope at that time

closes #39

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*