### PR TITLE
chore: gitignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,8 @@ desktop.ini
 # Node modules — in case someone forks and adds tooling
 node_modules/
 
+# Generated npm lockfile — project deliberately ships without a committed lockfile
+package-lock.json
+
 # Local git worktrees — created via superpowers:using-git-worktrees skill
 .worktrees/


### PR DESCRIPTION
## Summary

- Adds `package-lock.json` to `.gitignore`, grouped with the existing `node_modules/` entry
- Includes a brief comment explaining *why* it's ignored (project deliberately ships without a committed lockfile)

## Why

The project has only one devDependency (prettier). Running any `npm` command leaves an untracked `package-lock.json` in the working tree — pure noise in `git status` with no value to commit.

closes #40

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*