### PR TITLE
content: align site messaging with LinkedIn — MLOps positioning, end-to-end shipping

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <!-- CUSTOMIZE: Update this description for SEO / social sharing -->
     <meta
       name="description"
-      content="Christopher Beaulieu — Senior Software Engineer specializing in backend systems, data pipelines, and cloud infrastructure. Open to new opportunities."
+      content="Christopher Beaulieu — Senior Software Engineer specializing in backend services, MLOps pipelines, and GenAI developer tooling. Ships end-to-end. Open to new opportunities."
     />
     <title>Christopher Beaulieu — Senior Software Engineer</title>
 
@@ -14,7 +14,7 @@
     <meta property="og:title" content="Christopher Beaulieu — Senior Software Engineer" />
     <meta
       property="og:description"
-      content="Christopher Beaulieu — Senior Software Engineer specializing in backend systems, data pipelines, and cloud infrastructure. Open to new opportunities."
+      content="Christopher Beaulieu — Senior Software Engineer specializing in backend services, MLOps pipelines, and GenAI developer tooling. Ships end-to-end. Open to new opportunities."
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://christopherbeaulieu.net" />
@@ -23,7 +23,7 @@
     <meta name="twitter:title" content="Christopher Beaulieu — Senior Software Engineer" />
     <meta
       name="twitter:description"
-      content="Christopher Beaulieu — Senior Software Engineer specializing in backend systems, data pipelines, and cloud infrastructure. Open to new opportunities."
+      content="Christopher Beaulieu — Senior Software Engineer specializing in backend services, MLOps pipelines, and GenAI developer tooling. Ships end-to-end. Open to new opportunities."
     />
     <meta name="twitter:image" content="https://christopherbeaulieu.net/og-image.png" />
 
@@ -827,8 +827,8 @@
         <p class="hero-title">Senior Software Engineer</p>
 
         <p class="hero-tagline">
-          7 years building production analytics platforms, ML-enabled pipelines, and GenAI developer
-          tools at enterprise scale.
+          7+ years building backend services, MLOps pipelines, and GenAI developer tools at
+          enterprise scale. Ships end-to-end.
         </p>
 
         <div class="status-badge">Open to opportunities</div>
@@ -892,20 +892,31 @@
         <p class="section-label">About</p>
         <h2 class="section-title">A bit about me</h2>
         <p>
-          I'm a Senior Software Engineer with 7+ years of experience designing and operating
-          scalable backend, data, and analytics systems in enterprise production environments. At
-          Intel, I shipped platforms spanning production analytics services, ML-enabled data
-          pipelines, GenAI-powered developer tooling, and CI/CD automation — with measurable
-          outcomes attached to each.
+          Senior Software Engineer with 7+ years building backend, data, and ML systems at
+          enterprise scale — most recently at Intel, where I shipped production analytics platforms,
+          MLOps pipelines, and GenAI-powered developer tooling used across engineering
+          organizations.
         </p>
         <p>
-          I hold an M.S. in Computer Engineering from Georgia Tech. My core background is in C# and
-          Python, though I'm comfortable across the full stack of a modern backend system, from
-          distributed services to cloud infrastructure.
+          My work sits at the intersection of software, data, and real-world decision-making. I
+          design distributed services that scale, build data and ML pipelines that hold up in
+          production, and ship internal tools that people actually adopt. Recent examples include an
+          LLM-powered GenAI developer assistant that meaningfully improved code discovery, and
+          cloud-native REST APIs that let other teams plug decision-support systems into their own
+          workflows.
         </p>
         <p>
-          I'm currently open to new opportunities and would love to connect if you're building
-          something ambitious.
+          I ship end-to-end. My depth is in C#, Python, .NET, Azure, and the data/MLOps stack — and
+          I use modern AI tooling (Claude, primarily) to work fluently outside that core when
+          projects call for it. Alongside delivery, I've owned CI/CD strategy, mentored junior
+          engineers, and led teams through SCRUM adoption and production incidents.
+        </p>
+        <p>M.S. in Computer Engineering, Georgia Tech.</p>
+        <p>
+          Currently open to Senior Software Engineer, MLOps, or Data Platform Engineering roles
+          where I can own complex problems end-to-end and build platforms that make the people using
+          them measurably more effective. If you're working at the intersection of software, data,
+          and real-world decisions, I'd welcome a conversation.
         </p>
       </div>
     </section>
@@ -946,6 +957,18 @@
             <span class="chip">HTMX</span>
             <span class="chip">Pydantic</span>
             <span class="chip">BeautifulSoup4</span>
+          </div>
+        </div>
+
+        <div class="stack-group">
+          <p class="stack-group-label">ML &amp; MLOps</p>
+          <div class="chip-grid">
+            <span class="chip">Feature engineering</span>
+            <span class="chip">ML pipelines</span>
+            <span class="chip">Model integration</span>
+            <span class="chip">RAG</span>
+            <span class="chip">LLM integrations</span>
+            <span class="chip">Prompt engineering</span>
           </div>
         </div>
 
@@ -995,8 +1018,8 @@
                 improving signal identification and data workflows
               </li>
               <li>
-                Designed and operated large-scale ML-enabled data pipelines, including feature
-                engineering and production model integration
+                Designed and operated large-scale MLOps pipelines — feature engineering, model
+                integration, and production deployment — supporting ML-enabled analytics at scale
               </li>
               <li>
                 Built an internal GenAI-powered developer assistance platform using RAG and LLMs,
@@ -1242,9 +1265,7 @@
         <ul class="resume-highlights">
           <li>7+ years of enterprise software engineering experience</li>
           <li>M.S. Computer Engineering — Georgia Institute of Technology</li>
-          <li>
-            Full-stack backend expertise: distributed systems, ML pipelines, cloud infrastructure
-          </li>
+          <li>Backend, data, and MLOps depth — ships end-to-end</li>
         </ul>
         <!-- CUSTOMIZE: Update href to your resume file, e.g., href="resume.pdf" -->
         <a href="resume.pdf" class="btn-resume" download>


### PR DESCRIPTION
## Summary

Aligns christopherbeaulieu.net with updated LinkedIn positioning. Shifts framing from generic "backend/analytics" to **"Backend, Data, MLOps, GenAI — ships end-to-end"**. MLOps (not ML Engineer) is the accurate label — the work is productionizing/integrating models, not training/tuning them.

## Changes to `index.html`

1. **Meta descriptions** (×3: `meta[name="description"]`, `og:description`, `twitter:description`) — new MLOps/GenAI-focused copy ending in "Ships end-to-end."
2. **Hero tagline** — now "7+ years building backend services, MLOps pipelines, and GenAI developer tools at enterprise scale. Ships end-to-end."
3. **About section** — three paragraphs → five paragraphs; adds intersection-of-software/data/decision-making framing, explicit end-to-end + AI-tooling fluency, and an expanded roles-sought close.
4. **Skills** — new **ML & MLOps** chip group between *Frameworks & Backend* and *Tools & Platforms* (Feature engineering, ML pipelines, Model integration, RAG, LLM integrations, Prompt engineering).
5. **Experience bullet** — reframed from "ML-enabled data pipelines" to "MLOps pipelines — feature engineering, model integration, and production deployment".
6. **Resume section bullet** — "Full-stack backend expertise..." → "Backend, data, and MLOps depth — ships end-to-end".

## Verification

- `npm run format` — applied
- `npm run check` — `All matched files use Prettier code style!` (exit 0)
- Only `index.html` modified

## Acceptance (post-deploy on https://christopherbeaulieu.net)

- [ ] Hero tagline ends with "Ships end-to-end."
- [ ] About section has 5 paragraphs and mentions MLOps + AI tooling
- [ ] Skills section has "ML & MLOps" group between "Frameworks & Backend" and "Tools & Platforms"
- [ ] Experience bullet mentions "MLOps pipelines"
- [ ] Resume section bullet reads "Backend, data, and MLOps depth — ships end-to-end"

closes #43

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*