### PR TITLE
fix: integrate GoatCounter on-page visitor count display

### DIFF
--- a/index.html
+++ b/index.html
@@ -1330,7 +1330,7 @@
         <p>
           &copy; <span id="year"></span> Christopher Beaulieu. Built and hosted on GitHub Pages.
         </p>
-        <p class="visitor-bar">visitors: <span class="goatcounter-count" data-path="/"></span></p>
+        <p class="visitor-bar" id="gc-visitor-bar"></p>
       </div>
     </footer>
 
@@ -1465,27 +1465,39 @@
       src="//gc.zgo.at/count.js"
     ></script>
 
-    <!-- Show the visitor bar only when GoatCounter successfully populates the count span.
-       The bar is hidden by default (display:none in CSS) to avoid showing "visitors: "
-       with no number when the API is unreachable or the counter setting is disabled. -->
+    <!-- GoatCounter on-page visitor counter display.
+       count.js is tracking-only; the visitor counter requires an explicit
+       window.goatcounter.visit_count() call after count.js has loaded.
+       The bar is hidden by default (display:none in CSS) and revealed only when
+       GoatCounter successfully injects the count widget — avoiding a bare label
+       when the API is unreachable or the "Allow visitor counts" setting is off. -->
     <script>
       (function () {
-        var span = document.querySelector(".goatcounter-count");
         var bar = document.querySelector(".visitor-bar");
-        if (!span || !bar) return;
+        if (!bar) return;
 
-        // GoatCounter's count.js sets textContent on the span after the window load
-        // event fires. Use a MutationObserver to detect that write and reveal the bar.
+        // Poll until count.js has initialised window.goatcounter, then request
+        // the visitor count widget appended directly into the bar element.
+        var t = setInterval(function () {
+          if (window.goatcounter && window.goatcounter.visit_count) {
+            clearInterval(t);
+            window.goatcounter.visit_count({ append: ".visitor-bar", no_branding: true });
+          }
+        }, 100);
+
+        // Use a MutationObserver to reveal the bar the moment GoatCounter injects
+        // count content into it — avoids flashing an empty bar.
         var observer = new MutationObserver(function () {
-          if (span.textContent.trim() !== "") {
+          if (bar.children.length > 0) {
             bar.style.display = "";
             observer.disconnect();
           }
         });
-        observer.observe(span, { childList: true, characterData: true, subtree: true });
+        observer.observe(bar, { childList: true });
 
-        // Safety: disconnect after 10 s so we never leave an orphaned observer.
+        // Safety: stop polling and disconnect after 10 s if GoatCounter never loads.
         setTimeout(function () {
+          clearInterval(t);
           observer.disconnect();
         }, 10000);
       })();


### PR DESCRIPTION
## Summary

Fixes the visitor count bar never rendering on christopherbeaulieu.net. Server-side tracking was already working; the on-page display integration was incomplete.

## Root cause

`count.js` is GoatCounter's **tracking-only** script — it records page views but does not populate any DOM elements. The previous markup used `<span class="goatcounter-count" data-path="/">` and waited for `count.js` to fill it, but that pattern is not actually a GoatCounter API — it was never documented and `count.js` never touched the span. The `MutationObserver` never fired, `display:none` was never lifted, and the bar stayed invisible permanently.

## Fix

- Replace the inert `.goatcounter-count` span with an empty `<p class="visitor-bar" id="gc-visitor-bar">` container.
- Add a `setInterval` poll that waits for `window.goatcounter.visit_count` to become available (it's set asynchronously after `count.js` loads), then calls it with `{append: ".visitor-bar", no_branding: true}` to inject the count widget.
- Keep the `MutationObserver` pattern, now watching `.visitor-bar` for **child element insertion** (the widget GoatCounter injects) rather than text changes on a span. First child → `display:none` lifted.
- Keep the 10-second safety timeout; it now also clears the poll interval to avoid orphaned timers.
- Tracking `count.js` script tag is **untouched**.

## ⚠️ Required user action post-merge

The GoatCounter setting **"Allow adding visitor counts on your website"** must be enabled in the dashboard at [cmbdev.goatcounter.com](https://cmbdev.goatcounter.com) — it defaults to **off**. If it's off, `visit_count()` returns no content, the observer never fires, and the bar stays hidden (correct safe behavior, but not the desired outcome).

**Please enable that setting before testing the live site after merge.**

## Verification

- `npm run format` — unchanged (already clean)
- `npm run check` — `All matched files use Prettier code style!` (exit 0)
- Only `index.html` modified
- Localhost rendering cannot be fully verified — `visit_count()` against a real GoatCounter origin is required. Full verification happens on the live site post-merge.

closes #45

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*