### PR TITLE
enhancement: add alternateName to JSON-LD Person schema for nickname SEO

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
         "@context": "https://schema.org",
         "@type": "Person",
         "name": "Christopher Beaulieu",
+        "alternateName": ["Chris Beaulieu", "Chris"],
         "jobTitle": "Senior Software Engineer",
         "url": "https://christopherbeaulieu.net",
         "sameAs": [


### PR DESCRIPTION
## Summary

Adds `alternateName: ["Chris Beaulieu", "Chris"]` to the JSON-LD `Person` schema in `index.html` so Google can link nickname queries ("chris beaulieu") to the same entity as the full-name queries ("christopher beaulieu").

Schema-only per the decision in #46 — no visible body-copy changes.

## Change

Single addition between `name` and `jobTitle` in the JSON-LD block:

```json
"alternateName": ["Chris Beaulieu", "Chris"],
```

## Deliberately *not* changed

- **`sameAs` expansion** — the issue mentions Stack Overflow, X/Twitter, etc., but those can only be added once you confirm which accounts actually exist. Left GitHub + LinkedIn as-is. Can be done as a follow-up.
- **Visible copy** — explicitly deferred per the issue's scoping decision; "Christopher" stays throughout the page for branding consistency.

## ⚠️ User action required before closing #46

The issue has one acceptance criterion that can only be done by you:

> Verify `sitemap.xml` is submitted in Google Search Console and indexed; document GSC status in a closing comment on this issue.

After merge, please verify in GSC and add a short closing comment to #46 with the GSC status before marking it closed.

## Verification

- `npm run format` — unchanged (already clean)
- `npm run check` — `All matched files use Prettier code style!` (exit 0)
- Only `index.html` modified

closes #46

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*