### PR TITLE
fix(mobile): break-word + overflow-x clip to kill horizontal scroll (closes #52)

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,9 @@
         -webkit-font-smoothing: antialiased;
         background-image: radial-gradient(rgba(255,255,255,0.04) 1px, transparent 1px);
         background-size: 20px 20px;
+        overflow-wrap: break-word;
       }
+      html, body { overflow-x: clip; }
 
       a { color: var(--cyan); text-decoration: none; transition: opacity 150ms ease; }
       a:hover { opacity: 0.8; }

--- a/index.html
+++ b/index.html
@@ -399,6 +399,12 @@
         grid-template-columns: 1fr 1fr;
         gap: 56px 64px;
       }
+      /* CSS Grid items default to min-width: auto (sized to content's minimum
+         intrinsic size = longest unbreakable word). Override to 0 so the body's
+         overflow-wrap: break-word can actually kick in for the tech-name strings
+         in .stack-tools that have no whitespace between separator spans. Also
+         applied to .stack-also (flex container) for the same reason. */
+      .stack-grid > *, .stack-also { min-width: 0; }
       .stack-domain {
         padding-top: 4px;
         border-top: 2px solid var(--ink);


### PR DESCRIPTION
## Summary

Fixes the mobile horizontal scroll reported on the post-PR-#51 design refresh. Two CSS rules:

- `body { overflow-wrap: break-word }` — the actual fix. The .stack-tools and .stack-also-list markup concatenate tech names with `<span>·</span>` separators with no whitespace in between, making the run one unbreakable "word" from the browser's line-breaking POV. Same pattern with the email in `.contact-cta`. On <360px viewports these forced horizontal scroll. `break-word` lets the browser split mid-run when content would otherwise overflow.
- `html, body { overflow-x: clip }` — defensive backstop. Uses `clip` (not `hidden`) so `position: sticky` keeps working.

See Issue #52 corrected-diagnosis comment for full breakdown of why the original `.hero-name` hypothesis was wrong.

## Test plan

- [ ] Chrome DevTools → device emulation → iPhone SE (375x667) and 320px wide. No horizontal scrollbar at any scroll position.
- [ ] Stack section: tech name lines wrap to multiple lines instead of overflowing.
- [ ] Contact CTA: email breaks gracefully if it doesn't fit on one line.
- [ ] Sticky top nav still sticks on scroll (regression check for `overflow-x: clip`).
- [ ] Page still vertically scrolls.

closes #52

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_