### PR TITLE
fix(mobile): contact section overflow (closes #56)

### DIFF
--- a/index.html
+++ b/index.html
@@ -624,6 +624,14 @@
         grid-template-columns: 1.3fr 1fr;
         gap: 40px; align-items: end;
       }
+      /* min-width: 0 lets the grid items shrink below their content's
+         intrinsic min-width (the unbreakable email in .contact-cta).
+         max-width: 100% on the inline-flex CTA caps it at parent width
+         once the parent is willing to shrink. Together they let body's
+         overflow-wrap: break-word actually fire on the email text.
+         Mirrors the .stack-grid fix from PR #53. See issue #56. */
+      .contact-grid > * { min-width: 0; }
+      .contact-cta { max-width: 100%; }
       .contact-headline {
         font-family: var(--display); font-size: clamp(48px, 8vw, 72px);
         color: var(--ink); line-height: 1; letter-spacing: -0.03em;


### PR DESCRIPTION
## Summary

Fixes Issue #56 — the Contact section was not actually fixed by PR #53. The `overflow-x: clip` backstop hid the symptom but content was still overflowing the viewport, silently clipped.

Mirrors the `min-width: 0` fix that worked for `.stack-grid` (PR #53 commit `45b3cb7`):

```css
.contact-grid > * { min-width: 0; }
.contact-cta { max-width: 100%; }
```

`min-width: 0` frees the grid items from `min-width: auto`'s "must fit content's intrinsic min-width" rule. `max-width: 100%` caps the inline-flex CTA at parent width once the parent is willing to shrink. Body's existing `overflow-wrap: break-word` then breaks the long email mid-word as needed.

## Test plan

- [ ] DevTools mobile (375px and 320px wide) → Contact section. CTA button stays inside viewport, email breaks mid-word if needed.
- [ ] Inspect computed `width` of `.contact-cta` — should equal or be smaller than parent container width.
- [ ] Headline ("Let's build / something.") fits within viewport.
- [ ] Vertical scroll still works; horizontal scroll still blocked.
- [ ] Desktop layout unchanged (the fix only affects narrow viewports where content would otherwise overflow).

closes #56

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_