### PR TITLE
fix(nav): keep scroll-spy active during upward scroll inside sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -1286,6 +1286,18 @@
           const t = el.getBoundingClientRect().top;
           if (t >= 0 && t < bestTop) { bestTop = t; activeId = id; }
         });
+        // Fallback: while scrolling up inside a section its top is negative,
+        // so the loop above yields nothing. Pick the intersecting section with
+        // the greatest (least-negative) top — i.e. the one the viewport is in.
+        if (!activeId) {
+          let bestFallbackTop = -Infinity;
+          intersecting.forEach(id => {
+            const el = document.getElementById(id);
+            if (!el) return;
+            const t = el.getBoundingClientRect().top;
+            if (t > bestFallbackTop) { bestFallbackTop = t; activeId = id; }
+          });
+        }
         navLinks.forEach(l => l.classList.remove("active"));
         if (activeId) {
           document.querySelectorAll(`.nav-links a[href="#${activeId}"], .nav-drawer a[href="#${activeId}"]`).forEach(l => l.classList.add("active"));


### PR DESCRIPTION
## Summary
Adds a fallback to the nav scroll-spy IntersectionObserver so that the active nav link stays highlighted while the viewport is inside a section's body, not just while a section header is at-or-below the viewport top.

Closes #63

## Root cause
The IntersectionObserver callback only picked sections whose top had reached or passed the viewport top (`t >= 0`). While scrolling up *inside* a section, that section's top is still negative (above viewport), so it was filtered out — leaving `activeId = null` until the next section header arrived.

## Fix
When no candidate satisfies `t >= 0`, fall back to the intersecting section with the greatest (least-negative) top — the section the viewport is currently inside. Downward-scroll behavior is unchanged because the primary `t >= 0` filter still wins whenever any section qualifies.

## Diff
12 added lines, zero removals, zero reformatting:

```diff
+        // Fallback: while scrolling up inside a section its top is negative,
+        // so the loop above yields nothing. Pick the intersecting section with
+        // the greatest (least-negative) top — i.e. the one the viewport is in.
+        if (!activeId) {
+          let bestFallbackTop = -Infinity;
+          intersecting.forEach(id => {
+            const el = document.getElementById(id);
+            if (!el) return;
+            const t = el.getBoundingClientRect().top;
+            if (t > bestFallbackTop) { bestFallbackTop = t; activeId = id; }
+          });
+        }
```

## Behaviour walkthrough
- **Scrolling DOWN past a header** — the incoming section's top crosses 0; the primary loop picks it. Fallback never runs. *(unchanged)*
- **Scrolling UP past a header** — the section above immediately satisfies `t >= 0` and is picked by the primary loop. *(unchanged, no gap)*
- **Scrolling UP inside the body of a section** — the header is above the viewport (`t < 0`), so the primary loop yields nothing. The fallback picks the single intersecting section. **No more dead zone.**

## Test plan
- [ ] Pull the branch, open `index.html`, and scroll up/down through every section header on desktop. Confirm exactly one nav link is highlighted at all times once past the hero.
- [ ] Repeat on mobile width with the burger drawer open — drawer links share the `.active` class, so they should track the same way.
- [ ] Verify no regression of the prior multi-highlight fix from #6 / #7 (tap a nav link, confirm only that link highlights, not the previously-active one as well).

## Note on Prettier
`npm run check` fails on this branch — but it also fails on `main` for the same reasons. No new format issues are introduced. The pre-existing format drift is tracked separately in #64.

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*