### PR TITLE
chore: normalize Prettier formatting + enforce via CI

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,25 @@
+name: format
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  prettier:
+    name: prettier --check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run prettier --check
+        run: npm run check

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Verify formatting without writing changes (useful in CI):
 npm run check
 ```
 
+CI runs `npm run check` automatically on every push to `main` and every pull request via [`.github/workflows/format.yml`](.github/workflows/format.yml).
+
 ---
 
 ## Customizing

--- a/index.html
+++ b/index.html
@@ -3,17 +3,26 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="description" content="Christopher Beaulieu — Senior Software Engineer specializing in backend systems, data pipelines, and cloud infrastructure. Open to new opportunities." />
+    <meta
+      name="description"
+      content="Christopher Beaulieu — Senior Software Engineer specializing in backend systems, data pipelines, and cloud infrastructure. Open to new opportunities."
+    />
     <title>Christopher Beaulieu — Senior Software Engineer</title>
 
     <meta property="og:title" content="Christopher Beaulieu — Senior Software Engineer" />
-    <meta property="og:description" content="Christopher Beaulieu — Senior Software Engineer specializing in backend systems, data pipelines, and cloud infrastructure. Open to new opportunities." />
+    <meta
+      property="og:description"
+      content="Christopher Beaulieu — Senior Software Engineer specializing in backend systems, data pipelines, and cloud infrastructure. Open to new opportunities."
+    />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://christopherbeaulieu.net" />
     <meta property="og:image" content="https://christopherbeaulieu.net/assets/og-image.png?v=2" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Christopher Beaulieu — Senior Software Engineer" />
-    <meta name="twitter:description" content="Christopher Beaulieu — Senior Software Engineer specializing in backend systems, data pipelines, and cloud infrastructure. Open to new opportunities." />
+    <meta
+      name="twitter:description"
+      content="Christopher Beaulieu — Senior Software Engineer specializing in backend systems, data pipelines, and cloud infrastructure. Open to new opportunities."
+    />
     <meta name="twitter:image" content="https://christopherbeaulieu.net/assets/og-image.png?v=2" />
     <link rel="canonical" href="https://christopherbeaulieu.net" />
 
@@ -24,19 +33,35 @@
         "name": "Christopher Beaulieu",
         "jobTitle": "Senior Software Engineer",
         "url": "https://christopherbeaulieu.net",
-        "sameAs": ["https://github.com/cbeaulieu-gt", "https://linkedin.com/in/christopher-beaulieu"],
+        "sameAs": [
+          "https://github.com/cbeaulieu-gt",
+          "https://linkedin.com/in/christopher-beaulieu"
+        ],
         "email": "christopher_m_beaulieu@outlook.com"
       }
     </script>
 
-    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 96 96'%3E%3Crect width='96' height='96' fill='%230b0f14'/%3E%3Ctext x='48' y='62' text-anchor='middle' font-family='ui-monospace,Menlo,monospace' font-size='34' font-weight='700' fill='%237ee787'%3ECB%3C/text%3E%3C/svg%3E" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 96 96'%3E%3Crect width='96' height='96' fill='%230b0f14'/%3E%3Ctext x='48' y='62' text-anchor='middle' font-family='ui-monospace,Menlo,monospace' font-size='34' font-weight='700' fill='%237ee787'%3ECB%3C/text%3E%3C/svg%3E"
+    />
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700&family=Space+Grotesk:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
 
     <style>
-      *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
 
       :root {
         --bg: #0b0f14;
@@ -46,8 +71,8 @@
         --ink: #e6edf3;
         --body: #a6b0bd;
         --mute: #6b7785;
-        --rule: rgba(255,255,255,0.06);
-        --rule-strong: rgba(255,255,255,0.12);
+        --rule: rgba(255, 255, 255, 0.06);
+        --rule-strong: rgba(255, 255, 255, 0.12);
         --green: #7ee787;
         --green-dim: rgba(126, 231, 135, 0.12);
         --cyan: #5eead4;
@@ -63,7 +88,9 @@
         --max: 1180px;
       }
 
-      html { scroll-behavior: smooth; }
+      html {
+        scroll-behavior: smooth;
+      }
       body {
         background: var(--bg);
         color: var(--body);
@@ -71,44 +98,89 @@
         font-size: 16px;
         line-height: 1.6;
         -webkit-font-smoothing: antialiased;
-        background-image: radial-gradient(rgba(255,255,255,0.04) 1px, transparent 1px);
+        background-image: radial-gradient(rgba(255, 255, 255, 0.04) 1px, transparent 1px);
         background-size: 20px 20px;
         overflow-wrap: break-word;
       }
-      html, body { overflow-x: clip; }
+      html,
+      body {
+        overflow-x: clip;
+      }
 
-      a { color: var(--cyan); text-decoration: none; transition: opacity 150ms ease; }
-      a:hover { opacity: 0.8; }
-      img { max-width: 100%; display: block; }
+      a {
+        color: var(--cyan);
+        text-decoration: none;
+        transition: opacity 150ms ease;
+      }
+      a:hover {
+        opacity: 0.8;
+      }
+      img {
+        max-width: 100%;
+        display: block;
+      }
 
-      .container { max-width: var(--max); margin: 0 auto; padding: 0 32px; }
+      .container {
+        max-width: var(--max);
+        margin: 0 auto;
+        padding: 0 32px;
+      }
 
       /* ─── NAV ─── */
       .nav {
-        position: sticky; top: 0; z-index: 100;
-        background: rgba(11,15,20,0.78);
+        position: sticky;
+        top: 0;
+        z-index: 100;
+        background: rgba(11, 15, 20, 0.78);
         backdrop-filter: blur(12px);
         -webkit-backdrop-filter: blur(12px);
         border-bottom: 1px solid var(--rule);
       }
       .nav-inner {
-        max-width: var(--max); margin: 0 auto;
+        max-width: var(--max);
+        margin: 0 auto;
         padding: 8px 32px;
-        display: flex; justify-content: space-between; align-items: center;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
         font-family: var(--mono);
-        font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase;
+        font-size: 11px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
         color: var(--mute);
       }
-      .nav-brand { color: var(--ink); }
-      .nav-brand .diamond { color: var(--green); margin-right: 10px; }
-      .nav-links { display: flex; gap: 28px; align-items: center; }
-      .nav-links a { color: var(--mute); }
-      .nav-links a:hover { color: var(--ink); opacity: 1; }
-      .nav-links a.active { color: var(--green); }
-      .nav-links a.contact { color: var(--cyan); }
+      .nav-brand {
+        color: var(--ink);
+      }
+      .nav-brand .diamond {
+        color: var(--green);
+        margin-right: 10px;
+      }
+      .nav-links {
+        display: flex;
+        gap: 28px;
+        align-items: center;
+      }
+      .nav-links a {
+        color: var(--mute);
+      }
+      .nav-links a:hover {
+        color: var(--ink);
+        opacity: 1;
+      }
+      .nav-links a.active {
+        color: var(--green);
+      }
+      .nav-links a.contact {
+        color: var(--cyan);
+      }
       .nav-burger {
-        display: none; background: none; border: none;
-        color: var(--ink); font-size: 22px; cursor: pointer;
+        display: none;
+        background: none;
+        border: none;
+        color: var(--ink);
+        font-size: 22px;
+        cursor: pointer;
         padding: 4px 8px;
       }
       /* Drawer extends to top: 0 and uses padding-top to clear the nav.
@@ -120,54 +192,89 @@
          the burger-driven height. The nav's higher z-index (100 > 99) keeps
          it painting on top, producing an iOS-sheet style. See issue #54. */
       .nav-drawer {
-        position: fixed; top: 0; left: 0; right: 0;
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
         padding-top: 48px;
         background: var(--bg);
         border-bottom: 1px solid var(--rule-strong);
         z-index: 99;
       }
-      .nav-drawer ul { list-style: none; }
+      .nav-drawer ul {
+        list-style: none;
+      }
       .nav-drawer a {
-        display: flex; align-items: center; min-height: 48px;
+        display: flex;
+        align-items: center;
+        min-height: 48px;
         padding: 0 32px;
         font-family: var(--mono);
-        font-size: 12px; letter-spacing: 0.14em; text-transform: uppercase;
+        font-size: 12px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
         color: var(--body);
         border-top: 1px solid var(--rule);
       }
 
       /* ─── HERO ─── */
-      .hero { padding: 56px 0 64px; }
+      .hero {
+        padding: 56px 0 64px;
+      }
       .hero-status-row {
-        display: flex; gap: 12px; margin-bottom: 36px; flex-wrap: wrap;
+        display: flex;
+        gap: 12px;
+        margin-bottom: 36px;
+        flex-wrap: wrap;
       }
       .pill {
-        display: inline-flex; align-items: center; gap: 8px;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
         padding: 5px 12px;
-        font-family: var(--mono); font-size: 11px;
-        letter-spacing: 0.14em; text-transform: uppercase;
+        font-family: var(--mono);
+        font-size: 11px;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
       }
       .pill-green {
-        border: 1px solid var(--green); color: var(--green);
+        border: 1px solid var(--green);
+        color: var(--green);
       }
       .pill-mute {
-        border: 1px solid var(--rule); color: var(--mute);
+        border: 1px solid var(--rule);
+        color: var(--mute);
       }
       .pill-dot {
-        width: 6px; height: 6px; background: currentColor; border-radius: 50%;
+        width: 6px;
+        height: 6px;
+        background: currentColor;
+        border-radius: 50%;
         box-shadow: 0 0 8px currentColor;
         animation: pulse 2s ease-in-out infinite;
       }
-      @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
+      @keyframes pulse {
+        0%,
+        100% {
+          opacity: 1;
+        }
+        50% {
+          opacity: 0.35;
+        }
+      }
 
       .hero-name {
-        font-family: var(--display); font-weight: 700;
+        font-family: var(--display);
+        font-weight: 700;
         font-size: clamp(56px, 10vw, 96px);
         color: var(--ink);
-        letter-spacing: -0.035em; line-height: 0.96;
+        letter-spacing: -0.035em;
+        line-height: 0.96;
         margin: 0;
       }
-      .hero-name .punct { color: var(--green); }
+      .hero-name .punct {
+        color: var(--green);
+      }
 
       .hero-grid {
         display: grid;
@@ -182,74 +289,136 @@
         background: var(--panel);
         border: 1px solid var(--rule-strong);
         border-radius: 6px;
-        display: flex; flex-direction: column;
+        display: flex;
+        flex-direction: column;
         overflow: hidden;
       }
       .terminal-bar {
         padding: 10px 14px;
         background: var(--bg2);
         border-bottom: 1px solid var(--rule);
-        display: flex; align-items: center; gap: 10px;
+        display: flex;
+        align-items: center;
+        gap: 10px;
       }
-      .terminal-bar .dots { display: flex; gap: 6px; }
+      .terminal-bar .dots {
+        display: flex;
+        gap: 6px;
+      }
       .terminal-bar .dots span {
-        width: 10px; height: 10px; border-radius: 50%;
+        width: 10px;
+        height: 10px;
+        border-radius: 50%;
       }
-      .terminal-bar .dots span:nth-child(1) { background: #ff5f57; }
-      .terminal-bar .dots span:nth-child(2) { background: #febc2e; }
-      .terminal-bar .dots span:nth-child(3) { background: #28c840; }
+      .terminal-bar .dots span:nth-child(1) {
+        background: #ff5f57;
+      }
+      .terminal-bar .dots span:nth-child(2) {
+        background: #febc2e;
+      }
+      .terminal-bar .dots span:nth-child(3) {
+        background: #28c840;
+      }
       .terminal-bar .title {
-        flex: 1; text-align: center;
-        font-family: var(--mono); font-size: 11px;
-        color: var(--mute); letter-spacing: 0.08em;
+        flex: 1;
+        text-align: center;
+        font-family: var(--mono);
+        font-size: 11px;
+        color: var(--mute);
+        letter-spacing: 0.08em;
       }
       .terminal-body {
         padding: 20px 22px;
-        font-family: var(--mono); font-size: 13.5px; line-height: 1.7;
+        font-family: var(--mono);
+        font-size: 13.5px;
+        line-height: 1.7;
         flex: 1;
       }
-      .terminal-body .prompt { color: var(--green); margin-right: 8px; }
-      .terminal-body .cmd { color: var(--ink); }
-      .terminal-body .out { color: var(--body); }
-      .terminal-body .ok { color: var(--green); }
-      .terminal-body .info { color: var(--cyan); }
-      .terminal-body .gap { margin-bottom: 10px; }
+      .terminal-body .prompt {
+        color: var(--green);
+        margin-right: 8px;
+      }
+      .terminal-body .cmd {
+        color: var(--ink);
+      }
+      .terminal-body .out {
+        color: var(--body);
+      }
+      .terminal-body .ok {
+        color: var(--green);
+      }
+      .terminal-body .info {
+        color: var(--cyan);
+      }
+      .terminal-body .gap {
+        margin-bottom: 10px;
+      }
       .cursor {
         display: inline-block;
-        width: 8px; height: 1em; vertical-align: text-bottom;
+        width: 8px;
+        height: 1em;
+        vertical-align: text-bottom;
         background: var(--green);
         margin-left: 2px;
         animation: blink 1s steps(1) infinite;
       }
-      @keyframes blink { 50% { opacity: 0; } }
+      @keyframes blink {
+        50% {
+          opacity: 0;
+        }
+      }
 
-      .term-ctas { display: flex; gap: 10px; margin-top: 22px; flex-wrap: wrap; }
+      .term-ctas {
+        display: flex;
+        gap: 10px;
+        margin-top: 22px;
+        flex-wrap: wrap;
+      }
       .btn {
-        font-family: var(--mono); font-size: 12px;
+        font-family: var(--mono);
+        font-size: 12px;
         padding: 11px 16px;
-        letter-spacing: 0.12em; text-transform: uppercase;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
         font-weight: 700;
         border-radius: 3px;
         text-decoration: none;
-        display: inline-flex; align-items: center; gap: 8px;
-        transition: transform 150ms ease, opacity 150ms ease;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        transition:
+          transform 150ms ease,
+          opacity 150ms ease;
       }
-      .btn:hover { transform: translateY(-1px); opacity: 1; }
+      .btn:hover {
+        transform: translateY(-1px);
+        opacity: 1;
+      }
       .btn-primary {
-        background: var(--green); color: var(--bg);
+        background: var(--green);
+        color: var(--bg);
         border: 1px solid var(--green);
       }
-      .btn-primary:hover { box-shadow: 0 6px 20px rgba(126,231,135,0.25); }
+      .btn-primary:hover {
+        box-shadow: 0 6px 20px rgba(126, 231, 135, 0.25);
+      }
       .btn-cyan {
-        color: var(--cyan); border: 1px solid var(--cyan);
+        color: var(--cyan);
+        border: 1px solid var(--cyan);
         background: transparent;
       }
-      .btn-cyan:hover { background: var(--cyan-dim); }
+      .btn-cyan:hover {
+        background: var(--cyan-dim);
+      }
       .btn-ghost {
-        color: var(--body); border: 1px solid var(--rule-strong);
+        color: var(--body);
+        border: 1px solid var(--rule-strong);
         background: transparent;
       }
-      .btn-ghost:hover { color: var(--ink); border-color: var(--rule-strong); }
+      .btn-ghost:hover {
+        color: var(--ink);
+        border-color: var(--rule-strong);
+      }
 
       /* ─── STATUS PANEL (with photo) ─── */
       .status-panel {
@@ -257,24 +426,34 @@
         border: 1px solid var(--rule-strong);
         border-radius: 6px;
         padding: 22px;
-        display: flex; flex-direction: column;
+        display: flex;
+        flex-direction: column;
       }
       .status-panel-head {
-        font-family: var(--mono); font-size: 10px;
+        font-family: var(--mono);
+        font-size: 10px;
         color: var(--mute);
-        letter-spacing: 0.16em; text-transform: uppercase;
-        display: flex; justify-content: space-between;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
+        display: flex;
+        justify-content: space-between;
         margin-bottom: 16px;
       }
-      .status-panel-head .ok { color: var(--green); }
+      .status-panel-head .ok {
+        color: var(--green);
+      }
 
       .photo-row {
-        display: flex; gap: 14px; align-items: center;
-        padding-bottom: 16px; margin-bottom: 12px;
+        display: flex;
+        gap: 14px;
+        align-items: center;
+        padding-bottom: 16px;
+        margin-bottom: 12px;
         border-bottom: 1px solid var(--rule);
       }
       .photo-frame {
-        width: 78px; height: 78px;
+        width: 78px;
+        height: 78px;
         flex-shrink: 0;
         border: 1px solid var(--rule-strong);
         border-radius: 4px;
@@ -283,73 +462,125 @@
         background: var(--bg2);
       }
       .photo-frame img {
-        width: 100%; height: 100%;
+        width: 100%;
+        height: 100%;
         object-fit: cover;
         filter: saturate(0.85) contrast(1.05);
       }
       .photo-frame::after {
-        content: ""; position: absolute; inset: 0;
+        content: "";
+        position: absolute;
+        inset: 0;
         background-image: linear-gradient(transparent 95%, var(--cyan) 95%);
         background-size: 100% 8px;
         opacity: 0.18;
         pointer-events: none;
       }
       .photo-frame .badge {
-        position: absolute; top: 4px; left: 4px;
-        font-family: var(--mono); font-size: 8px;
-        letter-spacing: 0.14em; color: var(--green);
-        background: rgba(0,0,0,0.6);
+        position: absolute;
+        top: 4px;
+        left: 4px;
+        font-family: var(--mono);
+        font-size: 8px;
+        letter-spacing: 0.14em;
+        color: var(--green);
+        background: rgba(0, 0, 0, 0.6);
         padding: 2px 5px;
       }
-      .photo-meta { font-family: var(--mono); font-size: 11.5px; line-height: 1.6; }
-      .photo-meta .name { color: var(--ink); font-weight: 600; }
-      .photo-meta .role { color: var(--green); }
-      .photo-meta .loc { color: var(--mute); }
+      .photo-meta {
+        font-family: var(--mono);
+        font-size: 11.5px;
+        line-height: 1.6;
+      }
+      .photo-meta .name {
+        color: var(--ink);
+        font-weight: 600;
+      }
+      .photo-meta .role {
+        color: var(--green);
+      }
+      .photo-meta .loc {
+        color: var(--mute);
+      }
 
       .status-row {
-        display: flex; justify-content: space-between;
+        display: flex;
+        justify-content: space-between;
         padding: 9px 0;
         border-bottom: 1px solid var(--rule);
-        font-family: var(--mono); font-size: 12px;
+        font-family: var(--mono);
+        font-size: 12px;
       }
-      .status-row:last-of-type { border-bottom: none; }
-      .status-row .k { color: var(--mute); }
-      .status-row .v { color: var(--ink); font-weight: 600; }
-      .status-row .v.cyan { color: var(--purple); }
-      .status-row .v.green { color: var(--green); }
+      .status-row:last-of-type {
+        border-bottom: none;
+      }
+      .status-row .k {
+        color: var(--mute);
+      }
+      .status-row .v {
+        color: var(--ink);
+        font-weight: 600;
+      }
+      .status-row .v.cyan {
+        color: var(--purple);
+      }
+      .status-row .v.green {
+        color: var(--green);
+      }
 
       .now-card {
         margin-top: 14px;
         padding: 12px 14px;
         background: var(--bg2);
         border-left: 2px solid var(--green);
-        font-family: var(--mono); font-size: 11.5px;
+        font-family: var(--mono);
+        font-size: 11.5px;
         line-height: 1.6;
         color: var(--body);
       }
-      .now-card .h { color: var(--green); display: block; margin-bottom: 4px; }
+      .now-card .h {
+        color: var(--green);
+        display: block;
+        margin-bottom: 4px;
+      }
 
       /* ─── SECTION HEADERS ─── */
-      section { padding: 96px 0; }
+      section {
+        padding: 96px 0;
+      }
       .section-head {
-        display: flex; align-items: baseline; gap: 20px;
+        display: flex;
+        align-items: baseline;
+        gap: 20px;
         padding-bottom: 16px;
         border-bottom: 1px solid var(--rule-strong);
         margin-bottom: 40px;
       }
       .section-head .num {
-        font-family: var(--mono); font-size: 11px;
-        color: var(--green); letter-spacing: 0.16em;
+        font-family: var(--mono);
+        font-size: 11px;
+        color: var(--green);
+        letter-spacing: 0.16em;
       }
       .section-head h2 {
-        font-family: var(--display); font-size: clamp(26px, 4vw, 34px);
-        color: var(--ink); margin: 0;
-        font-weight: 700; letter-spacing: -0.02em;
+        font-family: var(--display);
+        font-size: clamp(26px, 4vw, 34px);
+        color: var(--ink);
+        margin: 0;
+        font-weight: 700;
+        letter-spacing: -0.02em;
       }
-      .section-head .rule { flex: 1; height: 1px; background: var(--rule); }
+      .section-head .rule {
+        flex: 1;
+        height: 1px;
+        background: var(--rule);
+      }
       .section-head .meta {
-        font-family: var(--mono); font-size: 10px;
-        color: var(--mute); letter-spacing: 0.14em; text-transform: uppercase;
+        font-family: var(--mono);
+        font-size: 10px;
+        color: var(--mute);
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
       }
 
       /* ─── ABOUT ─── */
@@ -359,26 +590,46 @@
         gap: 56px;
       }
       .about-grid p {
-        font-size: 16.5px; color: var(--body); line-height: 1.7;
+        font-size: 16.5px;
+        color: var(--body);
+        line-height: 1.7;
       }
-      .about-main p + p { margin-top: 14px; }
+      .about-main p + p {
+        margin-top: 14px;
+      }
       .about-photo {
-        display: flex; gap: 18px; align-items: center;
+        display: flex;
+        gap: 18px;
+        align-items: center;
         margin-bottom: 24px;
         padding-bottom: 22px;
         border-bottom: 1px solid var(--rule);
       }
       .about-photo .photo-frame {
-        width: 96px; height: 96px;
+        width: 96px;
+        height: 96px;
       }
-      .about-photo .photo-meta { font-family: var(--mono); font-size: 13px; line-height: 1.65; }
-      .about-photo .photo-meta .name { color: var(--ink); font-weight: 600; font-size: 14px; }
-      .about-photo .photo-meta .role { color: var(--green); }
-      .about-photo .photo-meta .loc { color: var(--mute); }
+      .about-photo .photo-meta {
+        font-family: var(--mono);
+        font-size: 13px;
+        line-height: 1.65;
+      }
+      .about-photo .photo-meta .name {
+        color: var(--ink);
+        font-weight: 600;
+        font-size: 14px;
+      }
+      .about-photo .photo-meta .role {
+        color: var(--green);
+      }
+      .about-photo .photo-meta .loc {
+        color: var(--mute);
+      }
 
       /* About vitals (right column) */
       .vitals {
-        display: flex; flex-direction: column;
+        display: flex;
+        flex-direction: column;
         gap: 14px;
       }
       .vital {
@@ -389,17 +640,22 @@
       }
       .vital-k {
         display: block;
-        font-family: var(--mono); font-size: 10px;
+        font-family: var(--mono);
+        font-size: 10px;
         color: var(--cyan);
-        letter-spacing: 0.16em; text-transform: uppercase;
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
         margin-bottom: 8px;
       }
       .vital-v {
-        font-family: var(--mono); font-size: 13px;
-        color: var(--body); line-height: 1.6;
+        font-family: var(--mono);
+        font-size: 13px;
+        color: var(--body);
+        line-height: 1.6;
       }
       .vital-v strong {
-        color: var(--ink); font-weight: 600;
+        color: var(--ink);
+        font-weight: 600;
       }
 
       /* ─── STACK (skills) ─── */
@@ -413,67 +669,106 @@
          overflow-wrap: break-word can actually kick in for the tech-name strings
          in .stack-tools that have no whitespace between separator spans. Also
          applied to .stack-also (flex container) for the same reason. */
-      .stack-grid > *, .stack-also { min-width: 0; }
+      .stack-grid > *,
+      .stack-also {
+        min-width: 0;
+      }
       .stack-domain {
         padding-top: 4px;
         border-top: 2px solid var(--ink);
       }
       .stack-domain-head {
-        display: flex; align-items: baseline; gap: 14px;
+        display: flex;
+        align-items: baseline;
+        gap: 14px;
         margin-top: 14px;
       }
       .stack-domain-head .n {
-        font-family: var(--mono); font-size: 11px;
-        color: var(--green); letter-spacing: 0.14em;
+        font-family: var(--mono);
+        font-size: 11px;
+        color: var(--green);
+        letter-spacing: 0.14em;
       }
       .stack-domain-head h3 {
-        font-family: var(--display); font-size: 26px;
-        color: var(--ink); margin: 0;
-        font-weight: 700; letter-spacing: -0.015em;
+        font-family: var(--display);
+        font-size: 26px;
+        color: var(--ink);
+        margin: 0;
+        font-weight: 700;
+        letter-spacing: -0.015em;
       }
       .stack-summary {
-        font-size: 15px; color: var(--body);
-        margin: 10px 0 18px; line-height: 1.55;
+        font-size: 15px;
+        color: var(--body);
+        margin: 10px 0 18px;
+        line-height: 1.55;
         max-width: 480px;
       }
       .stack-tools {
-        font-family: var(--mono); font-size: 13px;
+        font-family: var(--mono);
+        font-size: 13px;
         line-height: 1.85;
-        color: var(--ink); font-weight: 500;
+        color: var(--ink);
+        font-weight: 500;
       }
-      .stack-tools .sep { color: var(--mute); margin: 0 8px; }
+      .stack-tools .sep {
+        color: var(--mute);
+        margin: 0 8px;
+      }
 
       .stack-also {
-        margin-top: 48px; padding-top: 24px;
+        margin-top: 48px;
+        padding-top: 24px;
         border-top: 1px solid var(--rule);
-        display: flex; gap: 16px; align-items: baseline; flex-wrap: wrap;
+        display: flex;
+        gap: 16px;
+        align-items: baseline;
+        flex-wrap: wrap;
       }
       .stack-also-label {
-        font-family: var(--mono); font-size: 10px;
-        color: var(--mute); letter-spacing: 0.16em; text-transform: uppercase;
+        font-family: var(--mono);
+        font-size: 10px;
+        color: var(--mute);
+        letter-spacing: 0.16em;
+        text-transform: uppercase;
       }
       .stack-also-list {
-        font-family: var(--mono); font-size: 13px; color: var(--body);
+        font-family: var(--mono);
+        font-size: 13px;
+        color: var(--body);
       }
 
       /* ─── EXPERIENCE ─── */
       .exp-timeline {
-        display: flex; align-items: center; gap: 12px;
+        display: flex;
+        align-items: center;
+        gap: 12px;
         margin-bottom: 28px;
-        font-family: var(--mono); font-size: 10px;
-        color: var(--mute); letter-spacing: 0.14em;
+        font-family: var(--mono);
+        font-size: 10px;
+        color: var(--mute);
+        letter-spacing: 0.14em;
       }
       .exp-timeline .track {
-        flex: 1; height: 2px; background: var(--green);
+        flex: 1;
+        height: 2px;
+        background: var(--green);
         position: relative;
       }
       .exp-timeline .dot {
-        position: absolute; top: -3px;
-        width: 8px; height: 8px; border-radius: 50%;
+        position: absolute;
+        top: -3px;
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
         background: var(--green);
       }
-      .exp-timeline .dot.now { box-shadow: 0 0 10px var(--green); }
-      .exp-timeline .end { color: var(--green); }
+      .exp-timeline .dot.now {
+        box-shadow: 0 0 10px var(--green);
+      }
+      .exp-timeline .end {
+        color: var(--green);
+      }
 
       .exp-card {
         display: grid;
@@ -485,14 +780,18 @@
         border-top: 1px dashed var(--rule);
       }
       .exp-dates {
-        font-family: var(--mono); font-size: 11px;
+        font-family: var(--mono);
+        font-size: 11px;
         color: var(--green);
-        letter-spacing: 0.14em; text-transform: uppercase;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
       }
       .exp-duration {
-        font-family: var(--mono); font-size: 10px;
+        font-family: var(--mono);
+        font-size: 10px;
         color: var(--mute);
-        letter-spacing: 0.12em; text-transform: uppercase;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
         margin-top: 4px;
       }
       .exp-company {
@@ -502,33 +801,51 @@
         background: var(--green-dim);
         border: 1px solid var(--green);
         color: var(--green);
-        font-family: var(--mono); font-size: 11px;
-        font-weight: 700; letter-spacing: 0.1em;
+        font-family: var(--mono);
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: 0.1em;
       }
       .exp-role {
-        font-family: var(--display); font-size: 22px;
+        font-family: var(--display);
+        font-size: 22px;
         color: var(--ink);
-        font-weight: 700; letter-spacing: -0.01em;
+        font-weight: 700;
+        letter-spacing: -0.01em;
         margin-bottom: 14px;
       }
       .exp-bullets {
         list-style: none;
-        display: flex; flex-direction: column; gap: 10px;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
       }
       .exp-bullets li {
-        display: flex; gap: 12px;
-        font-size: 14.5px; color: var(--body); line-height: 1.6;
+        display: flex;
+        gap: 12px;
+        font-size: 14.5px;
+        color: var(--body);
+        line-height: 1.6;
       }
       .exp-bullets .marker {
-        font-family: var(--mono); font-size: 12px;
-        color: var(--green); margin-top: 2px;
+        font-family: var(--mono);
+        font-size: 12px;
+        color: var(--green);
+        margin-top: 2px;
         min-width: 22px;
       }
-      .exp-tech { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 14px; }
+      .exp-tech {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        margin-top: 14px;
+      }
       .exp-tech span {
-        font-family: var(--mono); font-size: 10px;
+        font-family: var(--mono);
+        font-size: 10px;
         color: var(--purple);
-        letter-spacing: 0.12em; text-transform: uppercase;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
         padding: 3px 9px;
         border: 1px solid var(--rule-strong);
         border-radius: 3px;
@@ -545,45 +862,67 @@
         border: 1px solid var(--rule-strong);
         border-radius: 6px;
         padding: 24px;
-        display: flex; flex-direction: column;
-        transition: border-color 150ms ease, transform 150ms ease, box-shadow 150ms ease;
+        display: flex;
+        flex-direction: column;
+        transition:
+          border-color 150ms ease,
+          transform 150ms ease,
+          box-shadow 150ms ease;
       }
-      .project.full { grid-column: 1 / -1; }
+      .project.full {
+        grid-column: 1 / -1;
+      }
       .project:hover {
         border-color: var(--rule-strong);
         transform: translateY(-3px);
-        box-shadow: 0 12px 36px rgba(0,0,0,0.35);
+        box-shadow: 0 12px 36px rgba(0, 0, 0, 0.35);
       }
       .project-head {
-        display: flex; align-items: baseline; gap: 10px; margin-bottom: 8px;
+        display: flex;
+        align-items: baseline;
+        gap: 10px;
+        margin-bottom: 8px;
       }
-      .project-head .arrow { color: var(--green); }
+      .project-head .arrow {
+        color: var(--green);
+      }
       .project-name {
-        font-family: var(--display); font-size: 20px;
-        color: var(--ink); font-weight: 700;
+        font-family: var(--display);
+        font-size: 20px;
+        color: var(--ink);
+        font-weight: 700;
         letter-spacing: -0.01em;
       }
       .project-kind {
         margin-left: auto;
-        font-family: var(--mono); font-size: 10px;
+        font-family: var(--mono);
+        font-size: 10px;
         color: var(--mute);
-        letter-spacing: 0.14em; text-transform: uppercase;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
       }
       .project-blurb {
-        font-size: 14.5px; color: var(--body);
-        line-height: 1.6; margin-bottom: 8px;
+        font-size: 14.5px;
+        color: var(--body);
+        line-height: 1.6;
+        margin-bottom: 8px;
       }
       .project-details {
-        font-size: 13px; color: var(--mute);
-        line-height: 1.6; margin-bottom: 12px;
+        font-size: 13px;
+        color: var(--mute);
+        line-height: 1.6;
+        margin-bottom: 12px;
       }
       .project-tags {
-        display: flex; flex-wrap: wrap; gap: 6px;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
         margin-top: auto;
         padding-top: 12px;
       }
       .project-tags span {
-        font-family: var(--mono); font-size: 10px;
+        font-family: var(--mono);
+        font-size: 10px;
         color: var(--purple);
         letter-spacing: 0.1em;
         padding: 2px 8px;
@@ -592,21 +931,26 @@
         border-radius: 3px;
       }
       .project-links {
-        display: flex; gap: 18px; margin-top: 14px;
+        display: flex;
+        gap: 18px;
+        margin-top: 14px;
         padding-top: 14px;
         border-top: 1px solid var(--rule);
       }
       .project-links a {
-        font-family: var(--mono); font-size: 11.5px;
+        font-family: var(--mono);
+        font-size: 11.5px;
         color: var(--blue);
-        letter-spacing: 0.1em; text-transform: uppercase;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
         font-weight: 600;
       }
 
       .ai-disclosure {
         margin-top: 32px;
         padding: 14px 18px;
-        font-family: var(--mono); font-size: 12px;
+        font-family: var(--mono);
+        font-size: 12px;
         line-height: 1.65;
         color: var(--mute);
         border-top: 1px solid var(--rule);
@@ -618,11 +962,15 @@
       }
 
       /* ─── CONTACT ─── */
-      section.contact { padding: 96px 0 80px; border-top: 1px solid var(--rule-strong); }
+      section.contact {
+        padding: 96px 0 80px;
+        border-top: 1px solid var(--rule-strong);
+      }
       .contact-grid {
         display: grid;
         grid-template-columns: 1.3fr 1fr;
-        gap: 40px; align-items: end;
+        gap: 40px;
+        align-items: end;
       }
       /* min-width: 0 lets the grid items shrink below their content's
          intrinsic min-width (the unbreakable email in .contact-cta).
@@ -630,23 +978,37 @@
          once the parent is willing to shrink. Together they let body's
          overflow-wrap: break-word actually fire on the email text.
          Mirrors the .stack-grid fix from PR #53. See issue #56. */
-      .contact-grid > * { min-width: 0; }
-      .contact-cta { max-width: 100%; }
+      .contact-grid > * {
+        min-width: 0;
+      }
+      .contact-cta {
+        max-width: 100%;
+      }
       .contact-headline {
-        font-family: var(--display); font-size: clamp(48px, 8vw, 72px);
-        color: var(--ink); line-height: 1; letter-spacing: -0.03em;
+        font-family: var(--display);
+        font-size: clamp(48px, 8vw, 72px);
+        color: var(--ink);
+        line-height: 1;
+        letter-spacing: -0.03em;
         font-weight: 700;
       }
-      .contact-headline .accent { color: var(--green); }
+      .contact-headline .accent {
+        color: var(--green);
+      }
       .contact-sub {
-        font-size: 16px; color: var(--body); margin-top: 14px;
+        font-size: 16px;
+        color: var(--body);
+        margin-top: 14px;
         max-width: 460px;
       }
       .contact-cta {
-        display: inline-flex; align-items: center; gap: 12px;
+        display: inline-flex;
+        align-items: center;
+        gap: 12px;
         margin-top: 24px;
         padding: 16px 22px;
-        background: var(--green); color: var(--bg);
+        background: var(--green);
+        color: var(--bg);
         font-family: var(--mono);
         /* Fluid font-size: floor 9.5px on narrow phones, ceiling 12.5px on
            desktop. Pairs with overflow-wrap: anywhere so the unbreakable
@@ -654,45 +1016,64 @@
            narrower than the floor allows. Mirrors the clamp() pattern used
            by .contact-headline above. See issue #58. */
         font-size: clamp(9.5px, 3vw, 12.5px);
-        font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase;
-        overflow-wrap: anywhere; word-break: break-word;
+        font-weight: 700;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        overflow-wrap: anywhere;
+        word-break: break-word;
         border-radius: 4px;
-        transition: transform 150ms ease, box-shadow 150ms ease;
+        transition:
+          transform 150ms ease,
+          box-shadow 150ms ease;
       }
       .contact-cta:hover {
         transform: translateY(-2px);
-        box-shadow: 0 12px 32px rgba(126,231,135,0.25);
+        box-shadow: 0 12px 32px rgba(126, 231, 135, 0.25);
         opacity: 1;
       }
       .contact-links {
-        display: flex; flex-direction: column; gap: 10px;
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
       }
       .contact-links a {
-        display: flex; justify-content: space-between; align-items: center;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
         padding: 16px 18px;
-        font-family: var(--mono); font-size: 12px;
+        font-family: var(--mono);
+        font-size: 12px;
         color: var(--body);
         letter-spacing: 0.06em;
         border: 1px solid var(--rule);
         border-radius: 4px;
-        transition: border-color 150ms ease, color 150ms ease;
+        transition:
+          border-color 150ms ease,
+          color 150ms ease;
       }
       .contact-links a:hover {
         border-color: var(--rule-strong);
         color: var(--ink);
         opacity: 1;
       }
-      .contact-links a .arrow { color: var(--cyan); }
+      .contact-links a .arrow {
+        color: var(--cyan);
+      }
 
       footer {
         padding: 24px 0 32px;
         border-top: 1px solid var(--rule);
       }
       .footer-row {
-        display: flex; justify-content: space-between; flex-wrap: wrap; gap: 16px;
-        font-family: var(--mono); font-size: 10px;
+        display: flex;
+        justify-content: space-between;
+        flex-wrap: wrap;
+        gap: 16px;
+        font-family: var(--mono);
+        font-size: 10px;
         color: var(--mute);
-        letter-spacing: 0.14em; text-transform: uppercase;
+        letter-spacing: 0.14em;
+        text-transform: uppercase;
       }
       .visitor-bar {
         margin-top: 8px;
@@ -708,26 +1089,46 @@
 
       /* ─── BACK TO TOP ─── */
       .back-to-top {
-        position: fixed; bottom: 28px; right: 28px;
+        position: fixed;
+        bottom: 28px;
+        right: 28px;
         z-index: 200;
-        display: flex; align-items: center; justify-content: center;
-        width: 44px; height: 44px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 44px;
+        height: 44px;
         background: var(--panel);
         border: 1px solid var(--rule-strong);
         border-radius: 4px;
         color: var(--body);
-        font-size: 18px; cursor: pointer;
-        opacity: 0; pointer-events: none;
-        transition: opacity 250ms ease, color 150ms ease, border-color 150ms ease, transform 150ms ease;
+        font-size: 18px;
+        cursor: pointer;
+        opacity: 0;
+        pointer-events: none;
+        transition:
+          opacity 250ms ease,
+          color 150ms ease,
+          border-color 150ms ease,
+          transform 150ms ease;
       }
-      .back-to-top.visible { opacity: 1; pointer-events: auto; }
-      .back-to-top:hover { color: var(--green); border-color: var(--green); transform: translateY(-2px); }
+      .back-to-top.visible {
+        opacity: 1;
+        pointer-events: auto;
+      }
+      .back-to-top:hover {
+        color: var(--green);
+        border-color: var(--green);
+        transform: translateY(-2px);
+      }
 
       /* ─── REVEAL ANIMATION ─── */
       .reveal {
         opacity: 0;
         transform: translateY(18px);
-        transition: opacity 700ms ease, transform 700ms ease;
+        transition:
+          opacity 700ms ease,
+          transform 700ms ease;
       }
       .reveal.in {
         opacity: 1;
@@ -735,29 +1136,71 @@
       }
 
       @media (prefers-reduced-motion: reduce) {
-        .reveal { opacity: 1; transform: none; transition: none; }
-        .pill-dot, .cursor { animation: none; }
+        .reveal {
+          opacity: 1;
+          transform: none;
+          transition: none;
+        }
+        .pill-dot,
+        .cursor {
+          animation: none;
+        }
       }
 
       /* ─── RESPONSIVE ─── */
       @media (max-width: 920px) {
-        .hero-grid { grid-template-columns: 1fr; }
-        .about-grid { grid-template-columns: 1fr; gap: 24px; }
-        .stack-grid { grid-template-columns: 1fr; gap: 36px; }
-        .exp-card { grid-template-columns: 1fr; gap: 14px; }
-        .projects-grid { grid-template-columns: 1fr; }
-        .contact-grid { grid-template-columns: 1fr; gap: 32px; }
+        .hero-grid {
+          grid-template-columns: 1fr;
+        }
+        .about-grid {
+          grid-template-columns: 1fr;
+          gap: 24px;
+        }
+        .stack-grid {
+          grid-template-columns: 1fr;
+          gap: 36px;
+        }
+        .exp-card {
+          grid-template-columns: 1fr;
+          gap: 14px;
+        }
+        .projects-grid {
+          grid-template-columns: 1fr;
+        }
+        .contact-grid {
+          grid-template-columns: 1fr;
+          gap: 32px;
+        }
       }
 
       @media (max-width: 640px) {
-        .container { padding: 0 20px; }
-        section { padding: 72px 0; }
-        .hero { padding: 32px 0 48px; }
-        .nav-links { display: none; }
-        .nav-burger { display: block; }
-        .terminal-body { font-size: 12.5px; padding: 16px; }
-        .term-ctas .btn { flex: 1; justify-content: center; }
-        .footer-row { font-size: 9px; gap: 8px; }
+        .container {
+          padding: 0 20px;
+        }
+        section {
+          padding: 72px 0;
+        }
+        .hero {
+          padding: 32px 0 48px;
+        }
+        .nav-links {
+          display: none;
+        }
+        .nav-burger {
+          display: block;
+        }
+        .terminal-body {
+          font-size: 12.5px;
+          padding: 16px;
+        }
+        .term-ctas .btn {
+          flex: 1;
+          justify-content: center;
+        }
+        .footer-row {
+          font-size: 9px;
+          gap: 8px;
+        }
       }
     </style>
   </head>
@@ -797,7 +1240,7 @@
           <span class="pill pill-mute">Coconut Creek, FL · Remote-friendly</span>
         </div>
 
-        <h1 class="hero-name reveal">Christopher<br>Beaulieu<span class="punct">.</span></h1>
+        <h1 class="hero-name reveal">Christopher<br />Beaulieu<span class="punct">.</span></h1>
 
         <div class="hero-grid">
           <!-- TERMINAL -->
@@ -818,12 +1261,22 @@
               <span>last sync · live</span>
             </div>
 
-            <div class="status-row"><span class="k">Years shipping</span><span class="v">7+</span></div>
-            <div class="status-row"><span class="k">GenAI/RAG in prod</span><span class="v green">yes</span></div>
+            <div class="status-row">
+              <span class="k">Years shipping</span><span class="v">7+</span>
+            </div>
+            <div class="status-row">
+              <span class="k">GenAI/RAG in prod</span><span class="v green">yes</span>
+            </div>
             <div class="status-row"><span class="k">Team lead</span><span class="v">yes</span></div>
-            <div class="status-row"><span class="k">Discipline</span><span class="v">Full-stack · backend-focused</span></div>
-            <div class="status-row"><span class="k">Domain expertise</span><span class="v">Data analytics · MLOps</span></div>
-            <div class="status-row"><span class="k">Stack focus</span><span class="v cyan">C# · Python · .NET</span></div>
+            <div class="status-row">
+              <span class="k">Discipline</span><span class="v">Full-stack · backend-focused</span>
+            </div>
+            <div class="status-row">
+              <span class="k">Domain expertise</span><span class="v">Data analytics · MLOps</span>
+            </div>
+            <div class="status-row">
+              <span class="k">Stack focus</span><span class="v cyan">C# · Python · .NET</span>
+            </div>
           </aside>
         </div>
       </div>
@@ -851,27 +1304,46 @@
                 <div class="loc">Coconut Creek, FL</div>
               </div>
             </div>
-            <p>I'm a Senior Software Engineer with 7+ years designing and operating scalable backend, data, and analytics systems in enterprise production environments. At Intel, I shipped platforms spanning production analytics services, ML-enabled data pipelines, GenAI-powered developer tooling, and CI/CD automation — with measurable outcomes attached to each.</p>
-            <p>I hold an M.S. in Computer Engineering from Georgia Tech. My core background is in C# and Python, though I'm comfortable across the full stack of a modern backend system, from distributed services to cloud infrastructure.</p>
-            <p>I lead small teams, mentor junior engineers, and treat shipping as a craft. I'm currently open to new opportunities and would love to connect if you're building something ambitious.</p>
+            <p>
+              I'm a Senior Software Engineer with 7+ years designing and operating scalable backend,
+              data, and analytics systems in enterprise production environments. At Intel, I shipped
+              platforms spanning production analytics services, ML-enabled data pipelines,
+              GenAI-powered developer tooling, and CI/CD automation — with measurable outcomes
+              attached to each.
+            </p>
+            <p>
+              I hold an M.S. in Computer Engineering from Georgia Tech. My core background is in C#
+              and Python, though I'm comfortable across the full stack of a modern backend system,
+              from distributed services to cloud infrastructure.
+            </p>
+            <p>
+              I lead small teams, mentor junior engineers, and treat shipping as a craft. I'm
+              currently open to new opportunities and would love to connect if you're building
+              something ambitious.
+            </p>
           </div>
 
           <aside class="vitals">
             <div class="vital">
               <span class="vital-k">Working on</span>
-              <p class="vital-v">Agentic systems, model tuning, and LLM-powered tooling — the through-line of my recent personal work.</p>
+              <p class="vital-v">
+                Agentic systems, model tuning, and LLM-powered tooling — the through-line of my
+                recent personal work.
+              </p>
             </div>
             <div class="vital">
               <span class="vital-k">Education</span>
-              <p class="vital-v"><strong>M.S. Computer Engineering</strong><br>Georgia Tech</p>
+              <p class="vital-v"><strong>M.S. Computer Engineering</strong><br />Georgia Tech</p>
             </div>
             <div class="vital">
               <span class="vital-k">Based in</span>
-              <p class="vital-v"><strong>Coconut Creek, FL</strong><br>Remote-friendly · ET</p>
+              <p class="vital-v"><strong>Coconut Creek, FL</strong><br />Remote-friendly · ET</p>
             </div>
             <div class="vital">
               <span class="vital-k">Looking for</span>
-              <p class="vital-v">Senior backend, ML platform, or full-stack roles at a team that ships.</p>
+              <p class="vital-v">
+                Senior backend, ML platform, or full-stack roles at a team that ships.
+              </p>
             </div>
           </aside>
         </div>
@@ -894,9 +1366,16 @@
               <span class="n">01</span>
               <h3>Data pipelines</h3>
             </div>
-            <p class="stack-summary">Large-scale ETL, feature engineering, statistical analysis, reliability modeling.</p>
+            <p class="stack-summary">
+              Large-scale ETL, feature engineering, statistical analysis, reliability modeling.
+            </p>
             <div class="stack-tools">
-              Python<span class="sep">·</span>Pandas<span class="sep">·</span>NumPy<span class="sep">·</span>SQL Server<span class="sep">·</span>PostgreSQL<span class="sep">·</span>Azure<span class="sep">·</span>Pydantic
+              Python<span class="sep">·</span>Pandas<span class="sep">·</span>NumPy<span class="sep"
+                >·</span
+              >SQL Server<span class="sep">·</span>PostgreSQL<span class="sep">·</span>Azure<span
+                class="sep"
+                >·</span
+              >Pydantic
             </div>
           </div>
 
@@ -905,9 +1384,16 @@
               <span class="n">02</span>
               <h3>ML / GenAI tooling</h3>
             </div>
-            <p class="stack-summary">RAG systems, multi-LLM orchestration, production model integration, developer assistants.</p>
+            <p class="stack-summary">
+              RAG systems, multi-LLM orchestration, production model integration, developer
+              assistants.
+            </p>
             <div class="stack-tools">
-              Claude API<span class="sep">·</span>OpenAI API<span class="sep">·</span>Gemini API<span class="sep">·</span>RAG<span class="sep">·</span>Multi-provider failover<span class="sep">·</span>Python
+              Claude API<span class="sep">·</span>OpenAI API<span class="sep">·</span>Gemini
+              API<span class="sep">·</span>RAG<span class="sep">·</span>Multi-provider failover<span
+                class="sep"
+                >·</span
+              >Python
             </div>
           </div>
 
@@ -916,9 +1402,16 @@
               <span class="n">03</span>
               <h3>Backend services</h3>
             </div>
-            <p class="stack-summary">Distributed services, REST APIs, internal platforms, full-stack feature work.</p>
+            <p class="stack-summary">
+              Distributed services, REST APIs, internal platforms, full-stack feature work.
+            </p>
             <div class="stack-tools">
-              C#<span class="sep">·</span>.NET / .NET Core<span class="sep">·</span>ASP.NET<span class="sep">·</span>Flask<span class="sep">·</span>HTMX<span class="sep">·</span>FastAPI<span class="sep">·</span>TypeScript
+              C#<span class="sep">·</span>.NET / .NET Core<span class="sep">·</span>ASP.NET<span
+                class="sep"
+                >·</span
+              >Flask<span class="sep">·</span>HTMX<span class="sep">·</span>FastAPI<span class="sep"
+                >·</span
+              >TypeScript
             </div>
           </div>
 
@@ -927,9 +1420,16 @@
               <span class="n">04</span>
               <h3>Cloud &amp; ops</h3>
             </div>
-            <p class="stack-summary">CI/CD ownership, container deployments, infrastructure for production analytics platforms.</p>
+            <p class="stack-summary">
+              CI/CD ownership, container deployments, infrastructure for production analytics
+              platforms.
+            </p>
             <div class="stack-tools">
-              Microsoft Azure<span class="sep">·</span>Docker<span class="sep">·</span>GitHub CI/CD<span class="sep">·</span>GitLab CI/CD<span class="sep">·</span>Linux<span class="sep">·</span>Windows Server<span class="sep">·</span>Artifactory
+              Microsoft Azure<span class="sep">·</span>Docker<span class="sep">·</span>GitHub
+              CI/CD<span class="sep">·</span>GitLab CI/CD<span class="sep">·</span>Linux<span
+                class="sep"
+                >·</span
+              >Windows Server<span class="sep">·</span>Artifactory
             </div>
           </div>
         </div>
@@ -937,12 +1437,12 @@
         <div class="stack-also reveal">
           <span class="stack-also-label">▸ also fluent in</span>
           <span class="stack-also-list">
-            C++ <span style="color: var(--mute);">·</span>
-            SQLite <span style="color: var(--mute);">·</span>
-            BeautifulSoup4 <span style="color: var(--mute);">·</span>
-            React <span style="color: var(--mute);">·</span>
-            Vite <span style="color: var(--mute);">·</span>
-            Playwright <span style="color: var(--mute);">·</span>
+            C++ <span style="color: var(--mute)">·</span> SQLite
+            <span style="color: var(--mute)">·</span> BeautifulSoup4
+            <span style="color: var(--mute)">·</span> React
+            <span style="color: var(--mute)">·</span> Vite
+            <span style="color: var(--mute)">·</span> Playwright
+            <span style="color: var(--mute)">·</span>
             SCRUM
           </span>
         </div>
@@ -962,9 +1462,9 @@
         <div class="exp-timeline reveal">
           <span>2018</span>
           <div class="track">
-            <div class="dot" style="left: 0;"></div>
-            <div class="dot" style="left: 28%;"></div>
-            <div class="dot now" style="right: 0;"></div>
+            <div class="dot" style="left: 0"></div>
+            <div class="dot" style="left: 28%"></div>
+            <div class="dot now" style="right: 0"></div>
           </div>
           <span class="end">2026 ●</span>
         </div>
@@ -978,14 +1478,45 @@
           <div>
             <div class="exp-role">Senior Data Analytics Software Engineer</div>
             <ul class="exp-bullets">
-              <li><span class="marker">01.</span><span>Led a team of engineers to build a production analytics platform, significantly improving signal identification and data workflows.</span></li>
-              <li><span class="marker">02.</span><span>Designed and operated large-scale ML-enabled data pipelines, including feature engineering and production model integration.</span></li>
-              <li><span class="marker">03.</span><span>Built an internal GenAI-powered developer assistance platform using RAG and LLMs, meaningfully improving code discovery and developer productivity.</span></li>
-              <li><span class="marker">04.</span><span>Owned CI/CD and deployment strategy across multiple applications, substantially reducing deployment time and production defect rates.</span></li>
-              <li><span class="marker">05.</span><span>Integrated SCRUM practices into team workflows and mentored junior engineers on development best practices.</span></li>
+              <li>
+                <span class="marker">01.</span
+                ><span
+                  >Led a team of engineers to build a production analytics platform, significantly
+                  improving signal identification and data workflows.</span
+                >
+              </li>
+              <li>
+                <span class="marker">02.</span
+                ><span
+                  >Designed and operated large-scale ML-enabled data pipelines, including feature
+                  engineering and production model integration.</span
+                >
+              </li>
+              <li>
+                <span class="marker">03.</span
+                ><span
+                  >Built an internal GenAI-powered developer assistance platform using RAG and LLMs,
+                  meaningfully improving code discovery and developer productivity.</span
+                >
+              </li>
+              <li>
+                <span class="marker">04.</span
+                ><span
+                  >Owned CI/CD and deployment strategy across multiple applications, substantially
+                  reducing deployment time and production defect rates.</span
+                >
+              </li>
+              <li>
+                <span class="marker">05.</span
+                ><span
+                  >Integrated SCRUM practices into team workflows and mentored junior engineers on
+                  development best practices.</span
+                >
+              </li>
             </ul>
             <div class="exp-tech">
-              <span>C#</span><span>.NET</span><span>Python</span><span>Azure</span><span>SQL Server</span><span>RAG</span><span>LLMs</span>
+              <span>C#</span><span>.NET</span><span>Python</span><span>Azure</span
+              ><span>SQL Server</span><span>RAG</span><span>LLMs</span>
             </div>
           </div>
         </article>
@@ -999,9 +1530,27 @@
           <div>
             <div class="exp-role">Software Engineer</div>
             <ul class="exp-bullets">
-              <li><span class="marker">01.</span><span>Developed analytics and statistical analysis applications supporting reliability modeling and failure-rate analysis.</span></li>
-              <li><span class="marker">02.</span><span>Improved analytical algorithms, achieving significant performance gains and reduced defect rates.</span></li>
-              <li><span class="marker">03.</span><span>Designed reusable application frameworks for backend data services and implemented CI/CD automation.</span></li>
+              <li>
+                <span class="marker">01.</span
+                ><span
+                  >Developed analytics and statistical analysis applications supporting reliability
+                  modeling and failure-rate analysis.</span
+                >
+              </li>
+              <li>
+                <span class="marker">02.</span
+                ><span
+                  >Improved analytical algorithms, achieving significant performance gains and
+                  reduced defect rates.</span
+                >
+              </li>
+              <li>
+                <span class="marker">03.</span
+                ><span
+                  >Designed reusable application frameworks for backend data services and
+                  implemented CI/CD automation.</span
+                >
+              </li>
             </ul>
             <div class="exp-tech">
               <span>C#</span><span>.NET</span><span>Python</span><span>SQL Server</span>
@@ -1028,13 +1577,23 @@
               <span class="project-name">RSL Siege Manager</span>
               <span class="project-kind">Open source · Live</span>
             </div>
-            <p class="project-blurb">An open-source web app for managing Raid: Shadow Legends clan siege assignments — self-hostable anywhere Docker runs.</p>
-            <p class="project-details">Drag-and-drop assignment board with an auto-fill algorithm, a real-time validation engine, PNG battle card generation via Playwright, and Discord DM notifications. Reference deployment runs on Azure Container Apps behind Discord auth.</p>
+            <p class="project-blurb">
+              An open-source web app for managing Raid: Shadow Legends clan siege assignments —
+              self-hostable anywhere Docker runs.
+            </p>
+            <p class="project-details">
+              Drag-and-drop assignment board with an auto-fill algorithm, a real-time validation
+              engine, PNG battle card generation via Playwright, and Discord DM notifications.
+              Reference deployment runs on Azure Container Apps behind Discord auth.
+            </p>
             <div class="project-tags">
-              <span>FastAPI</span><span>React</span><span>TypeScript</span><span>PostgreSQL</span><span>Docker</span><span>Discord</span><span>Azure</span>
+              <span>FastAPI</span><span>React</span><span>TypeScript</span><span>PostgreSQL</span
+              ><span>Docker</span><span>Discord</span><span>Azure</span>
             </div>
             <div class="project-links">
-              <a href="https://github.com/cbeaulieu-gt/siege-web" target="_blank" rel="noopener">GitHub →</a>
+              <a href="https://github.com/cbeaulieu-gt/siege-web" target="_blank" rel="noopener"
+                >GitHub →</a
+              >
               <a href="https://rslsiege.com" target="_blank" rel="noopener">Live site →</a>
             </div>
           </article>
@@ -1045,14 +1604,27 @@
               <span class="project-name">Job Matcher</span>
               <span class="project-kind">Solo · LLM pipeline</span>
             </div>
-            <p class="project-blurb">An LLM-powered job search pipeline that fetches listings from 9 sources, scores each description against your skills profile, and surfaces ranked results in a local web UI.</p>
-            <p class="project-details">Multi-provider scoring (Claude, GPT-4, Gemini) with cost-per-call awareness and provider failover. Data stays local. One external contribution merged — a DB query optimization from a community fork.</p>
+            <p class="project-blurb">
+              An LLM-powered job search pipeline that fetches listings from 9 sources, scores each
+              description against your skills profile, and surfaces ranked results in a local web
+              UI.
+            </p>
+            <p class="project-details">
+              Multi-provider scoring (Claude, GPT-4, Gemini) with cost-per-call awareness and
+              provider failover. Data stays local. One external contribution merged — a DB query
+              optimization from a community fork.
+            </p>
             <div class="project-tags">
-              <span>Python</span><span>Flask</span><span>SQLite</span><span>HTMX</span><span>Pydantic</span><span>Multi-LLM</span><span>BS4</span>
+              <span>Python</span><span>Flask</span><span>SQLite</span><span>HTMX</span
+              ><span>Pydantic</span><span>Multi-LLM</span><span>BS4</span>
             </div>
             <div class="project-links">
-              <a href="https://github.com/cbeaulieu-gt/job-matcher" target="_blank" rel="noopener">GitHub →</a>
-              <a href="https://christopherbeaulieu.net/job-matcher/" target="_blank" rel="noopener">Landing →</a>
+              <a href="https://github.com/cbeaulieu-gt/job-matcher" target="_blank" rel="noopener"
+                >GitHub →</a
+              >
+              <a href="https://christopherbeaulieu.net/job-matcher/" target="_blank" rel="noopener"
+                >Landing →</a
+              >
             </div>
           </article>
 
@@ -1062,13 +1634,27 @@
               <span class="project-name">Support Triage Agent</span>
               <span class="project-kind">Hackathon · Judging</span>
             </div>
-            <p class="project-blurb">A terminal-based AI agent that triages support tickets across HackerRank, Claude, and Visa product corpora. Built solo for HackerRank Orchestrate (May 2026, 24 hrs).</p>
-            <p class="project-details">Nine-stage RAG pipeline — preprocess → safety → router → query expansion → classifier → retrieval → product-area resolution → abstain → generate — with per-stage unit tests, structured run tracing, and explicit abstention on out-of-corpus or high-risk tickets. Multi-provider LLM client with deterministic outputs.</p>
+            <p class="project-blurb">
+              A terminal-based AI agent that triages support tickets across HackerRank, Claude, and
+              Visa product corpora. Built solo for HackerRank Orchestrate (May 2026, 24 hrs).
+            </p>
+            <p class="project-details">
+              Nine-stage RAG pipeline — preprocess → safety → router → query expansion → classifier
+              → retrieval → product-area resolution → abstain → generate — with per-stage unit
+              tests, structured run tracing, and explicit abstention on out-of-corpus or high-risk
+              tickets. Multi-provider LLM client with deterministic outputs.
+            </p>
             <div class="project-tags">
-              <span>Python</span><span>RAG</span><span>Multi-LLM</span><span>Pydantic</span><span>pytest</span><span>Agent</span><span>CLI</span>
+              <span>Python</span><span>RAG</span><span>Multi-LLM</span><span>Pydantic</span
+              ><span>pytest</span><span>Agent</span><span>CLI</span>
             </div>
             <div class="project-links">
-              <a href="https://github.com/cbeaulieu-gt/hackathon-llm-support-agent" target="_blank" rel="noopener">GitHub →</a>
+              <a
+                href="https://github.com/cbeaulieu-gt/hackathon-llm-support-agent"
+                target="_blank"
+                rel="noopener"
+                >GitHub →</a
+              >
             </div>
           </article>
 
@@ -1078,13 +1664,36 @@
               <span class="project-name">Qwen3.5 Quantization Study</span>
               <span class="project-kind">Research · Methodology</span>
             </div>
-            <p class="project-blurb">A 4-iteration empirical study quantizing Qwen3.5-0.8B for an agent on a CPU-only consumer-class envelope (8 threads, 16 GB).</p>
-            <p class="project-details">Falsified the bandwidth-bound prediction at Iter-1, validated a refined dequant-overhead mechanism at Iter-2, and confirmed a novel <em style="color: var(--ink); font-style: normal;">KV-noise-as-attention-regularization</em> hypothesis via a directional series. Recommended config: <strong style="color: var(--green); font-weight: 700;">+18–27% decode</strong>, <strong style="color: var(--green); font-weight: 700;">−16–31% memory</strong>, no quality regression.</p>
+            <p class="project-blurb">
+              A 4-iteration empirical study quantizing Qwen3.5-0.8B for an agent on a CPU-only
+              consumer-class envelope (8 threads, 16 GB).
+            </p>
+            <p class="project-details">
+              Falsified the bandwidth-bound prediction at Iter-1, validated a refined
+              dequant-overhead mechanism at Iter-2, and confirmed a novel
+              <em style="color: var(--ink); font-style: normal"
+                >KV-noise-as-attention-regularization</em
+              >
+              hypothesis via a directional series. Recommended config:
+              <strong style="color: var(--green); font-weight: 700">+18–27% decode</strong>,
+              <strong style="color: var(--green); font-weight: 700">−16–31% memory</strong>, no
+              quality regression.
+            </p>
             <div class="project-tags">
-              <span>Qwen3.5</span><span>llama.cpp</span><span>GGUF</span><span>Quantization</span><span>Docker</span><span>CPU-only</span><span>Python</span>
+              <span>Qwen3.5</span><span>llama.cpp</span><span>GGUF</span><span>Quantization</span
+              ><span>Docker</span><span>CPU-only</span><span>Python</span>
             </div>
             <div class="project-links">
-              <span style="font-family: var(--mono); font-size: 11.5px; color: var(--mute); letter-spacing: 0.1em; text-transform: uppercase;">Repo · TBD</span>
+              <span
+                style="
+                  font-family: var(--mono);
+                  font-size: 11.5px;
+                  color: var(--mute);
+                  letter-spacing: 0.1em;
+                  text-transform: uppercase;
+                "
+                >Repo · TBD</span
+              >
             </div>
           </article>
 
@@ -1094,16 +1703,22 @@
               <span class="project-name">More on GitHub</span>
               <span class="project-kind">Profile · @cbeaulieu-gt</span>
             </div>
-            <p class="project-blurb">Side projects, experiments, and open-source contributions live on my GitHub profile.</p>
-            <div class="project-links" style="border-top: none; padding-top: 0; margin-top: 4px;">
-              <a href="https://github.com/cbeaulieu-gt" target="_blank" rel="noopener">View profile →</a>
+            <p class="project-blurb">
+              Side projects, experiments, and open-source contributions live on my GitHub profile.
+            </p>
+            <div class="project-links" style="border-top: none; padding-top: 0; margin-top: 4px">
+              <a href="https://github.com/cbeaulieu-gt" target="_blank" rel="noopener"
+                >View profile →</a
+              >
             </div>
           </article>
         </div>
 
         <p class="ai-disclosure">
           <span class="k">// note</span>
-          AI tooling (Claude Code, GPT, Cursor) was used to varying degrees across all of the above — for research, code generation, and validation. Architectural decisions, methodology, and shipped outcomes are mine.
+          AI tooling (Claude Code, GPT, Cursor) was used to varying degrees across all of the above
+          — for research, code generation, and validation. Architectural decisions, methodology, and
+          shipped outcomes are mine.
         </p>
       </div>
     </section>
@@ -1119,16 +1734,26 @@
         </div>
         <div class="contact-grid reveal">
           <div>
-            <div class="contact-headline">Let's build<br><span class="accent">something.</span></div>
-            <p class="contact-sub">I'm open to senior backend, data, and ML platform roles. Inbox is always on.</p>
+            <div class="contact-headline">
+              Let's build<br /><span class="accent">something.</span>
+            </div>
+            <p class="contact-sub">
+              I'm open to senior backend, data, and ML platform roles. Inbox is always on.
+            </p>
             <a class="contact-cta" href="mailto:christopher_m_beaulieu@outlook.com">
               POST /hello → christopher_m_beaulieu@outlook.com
             </a>
           </div>
           <div class="contact-links">
-            <a href="assets/resume.pdf" download><span>GET /resume.pdf</span><span class="arrow">→</span></a>
-            <a href="https://github.com/cbeaulieu-gt" target="_blank" rel="noopener"><span>GET /github</span><span class="arrow">→</span></a>
-            <a href="https://linkedin.com/in/christopher-beaulieu" target="_blank" rel="noopener"><span>GET /linkedin</span><span class="arrow">→</span></a>
+            <a href="assets/resume.pdf" download
+              ><span>GET /resume.pdf</span><span class="arrow">→</span></a
+            >
+            <a href="https://github.com/cbeaulieu-gt" target="_blank" rel="noopener"
+              ><span>GET /github</span><span class="arrow">→</span></a
+            >
+            <a href="https://linkedin.com/in/christopher-beaulieu" target="_blank" rel="noopener"
+              ><span>GET /linkedin</span><span class="arrow">→</span></a
+            >
           </div>
         </div>
       </div>
@@ -1155,7 +1780,10 @@
       const terminalBody = document.getElementById("terminal-body");
       const lines = [
         { html: '<span class="prompt">$</span><span class="cmd">whoami --verbose</span>' },
-        { html: '<span class="out">Senior Software Engineer · Backend / Data / ML platforms</span>', gap: true },
+        {
+          html: '<span class="out">Senior Software Engineer · Backend / Data / ML platforms</span>',
+          gap: true,
+        },
         { html: '<span class="prompt">$</span><span class="cmd">cat tagline.txt</span>' },
         { html: '<span class="out">7 years building production analytics platforms,</span>' },
         { html: '<span class="out">ML-enabled pipelines, and GenAI developer tools</span>' },
@@ -1166,7 +1794,7 @@
       ];
 
       function typeOut(line, target, speed) {
-        return new Promise(resolve => {
+        return new Promise((resolve) => {
           // Strip markup to get plain text length, but type the markup
           const tmp = document.createElement("div");
           tmp.innerHTML = line.html;
@@ -1185,7 +1813,7 @@
           let n;
           while ((n = walker.nextNode())) textNodes.push(n);
           const charSpans = [];
-          textNodes.forEach(tn => {
+          textNodes.forEach((tn) => {
             const parent = tn.parentNode;
             const frag = document.createDocumentFragment();
             for (const ch of tn.textContent) {
@@ -1219,10 +1847,10 @@
 
       async function runTyper() {
         // Wait for hero to be visible-ish
-        await new Promise(r => setTimeout(r, 250));
+        await new Promise((r) => setTimeout(r, 250));
         for (const line of lines) {
           await typeOut(line, terminalBody, 14);
-          await new Promise(r => setTimeout(r, 80));
+          await new Promise((r) => setTimeout(r, 80));
         }
         // Final blinking cursor on its own line
         const final = document.createElement("div");
@@ -1233,7 +1861,7 @@
       // Honor reduced motion: render all lines instantly
       const prefersReduced = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
       if (prefersReduced) {
-        lines.forEach(l => {
+        lines.forEach((l) => {
           const wrap = document.createElement("div");
           if (l.gap) wrap.classList.add("gap");
           wrap.innerHTML = l.html;
@@ -1253,7 +1881,7 @@
       const vh = window.innerHeight;
       const aboveFold = [];
       const belowFold = [];
-      allReveal.forEach(el => {
+      allReveal.forEach((el) => {
         const top = el.getBoundingClientRect().top;
         if (top < vh * 0.9) aboveFold.push(el);
         else belowFold.push(el);
@@ -1261,68 +1889,106 @@
       aboveFold.forEach((el, i) => {
         setTimeout(() => el.classList.add("in"), 80 + i * 90);
       });
-      const revealObserver = new IntersectionObserver((entries) => {
-        entries.forEach(e => {
-          if (e.isIntersecting) {
-            e.target.classList.add("in");
-            revealObserver.unobserve(e.target);
-          }
-        });
-      }, { threshold: 0.12, rootMargin: "0px 0px -40px 0px" });
-      belowFold.forEach(el => revealObserver.observe(el));
+      const revealObserver = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((e) => {
+            if (e.isIntersecting) {
+              e.target.classList.add("in");
+              revealObserver.unobserve(e.target);
+            }
+          });
+        },
+        { threshold: 0.12, rootMargin: "0px 0px -40px 0px" },
+      );
+      belowFold.forEach((el) => revealObserver.observe(el));
 
       // ─── Nav scroll spy ───
-      const navLinks = document.querySelectorAll('.nav-links a[href^="#"], .nav-drawer a[href^="#"]');
+      const navLinks = document.querySelectorAll(
+        '.nav-links a[href^="#"], .nav-drawer a[href^="#"]',
+      );
       const intersecting = new Set();
-      const sectionObs = new IntersectionObserver((entries) => {
-        entries.forEach(e => {
-          if (e.isIntersecting) intersecting.add(e.target.id);
-          else intersecting.delete(e.target.id);
-        });
-        let activeId = null, bestTop = Infinity;
-        intersecting.forEach(id => {
-          const el = document.getElementById(id);
-          if (!el) return;
-          const t = el.getBoundingClientRect().top;
-          if (t >= 0 && t < bestTop) { bestTop = t; activeId = id; }
-        });
-        // Fallback: while scrolling up inside a section its top is negative,
-        // so the loop above yields nothing. Pick the intersecting section with
-        // the greatest (least-negative) top — i.e. the one the viewport is in.
-        if (!activeId) {
-          let bestFallbackTop = -Infinity;
-          intersecting.forEach(id => {
+      const sectionObs = new IntersectionObserver(
+        (entries) => {
+          entries.forEach((e) => {
+            if (e.isIntersecting) intersecting.add(e.target.id);
+            else intersecting.delete(e.target.id);
+          });
+          let activeId = null,
+            bestTop = Infinity;
+          intersecting.forEach((id) => {
             const el = document.getElementById(id);
             if (!el) return;
             const t = el.getBoundingClientRect().top;
-            if (t > bestFallbackTop) { bestFallbackTop = t; activeId = id; }
+            if (t >= 0 && t < bestTop) {
+              bestTop = t;
+              activeId = id;
+            }
           });
-        }
-        navLinks.forEach(l => l.classList.remove("active"));
-        if (activeId) {
-          document.querySelectorAll(`.nav-links a[href="#${activeId}"], .nav-drawer a[href="#${activeId}"]`).forEach(l => l.classList.add("active"));
-        }
-      }, { rootMargin: "-20% 0px -70% 0px", threshold: 0 });
-      document.querySelectorAll("section[id]").forEach(s => sectionObs.observe(s));
+          // Fallback: while scrolling up inside a section its top is negative,
+          // so the loop above yields nothing. Pick the intersecting section with
+          // the greatest (least-negative) top — i.e. the one the viewport is in.
+          if (!activeId) {
+            let bestFallbackTop = -Infinity;
+            intersecting.forEach((id) => {
+              const el = document.getElementById(id);
+              if (!el) return;
+              const t = el.getBoundingClientRect().top;
+              if (t > bestFallbackTop) {
+                bestFallbackTop = t;
+                activeId = id;
+              }
+            });
+          }
+          navLinks.forEach((l) => l.classList.remove("active"));
+          if (activeId) {
+            document
+              .querySelectorAll(
+                `.nav-links a[href="#${activeId}"], .nav-drawer a[href="#${activeId}"]`,
+              )
+              .forEach((l) => l.classList.add("active"));
+          }
+        },
+        { rootMargin: "-20% 0px -70% 0px", threshold: 0 },
+      );
+      document.querySelectorAll("section[id]").forEach((s) => sectionObs.observe(s));
 
       // ─── Burger drawer ───
       const burger = document.querySelector(".nav-burger");
       const drawer = document.querySelector(".nav-drawer");
       function toggleDrawer() {
         const open = !drawer.hasAttribute("hidden");
-        if (open) { drawer.setAttribute("hidden", ""); burger.setAttribute("aria-expanded", "false"); burger.textContent = "☰"; }
-        else { drawer.removeAttribute("hidden"); burger.setAttribute("aria-expanded", "true"); burger.textContent = "✕"; }
+        if (open) {
+          drawer.setAttribute("hidden", "");
+          burger.setAttribute("aria-expanded", "false");
+          burger.textContent = "☰";
+        } else {
+          drawer.removeAttribute("hidden");
+          burger.setAttribute("aria-expanded", "true");
+          burger.textContent = "✕";
+        }
       }
       burger.addEventListener("click", toggleDrawer);
-      drawer.querySelectorAll("a").forEach(a => a.addEventListener("click", () => { drawer.setAttribute("hidden", ""); burger.setAttribute("aria-expanded", "false"); burger.textContent = "☰"; }));
-      document.addEventListener("keydown", e => { if (e.key === "Escape" && !drawer.hasAttribute("hidden")) toggleDrawer(); });
+      drawer.querySelectorAll("a").forEach((a) =>
+        a.addEventListener("click", () => {
+          drawer.setAttribute("hidden", "");
+          burger.setAttribute("aria-expanded", "false");
+          burger.textContent = "☰";
+        }),
+      );
+      document.addEventListener("keydown", (e) => {
+        if (e.key === "Escape" && !drawer.hasAttribute("hidden")) toggleDrawer();
+      });
 
       // ─── Back to top ───
       const btt = document.getElementById("backToTop");
-      window.addEventListener("scroll", () => {
-        if (window.scrollY > 500) btt.classList.add("visible");
-        else btt.classList.remove("visible");
-      }, { passive: true });
+      window.addEventListener(
+        "scroll",
+        () => {
+          if (window.scrollY > 500) btt.classList.add("visible");
+          else btt.classList.remove("visible");
+        },
+        { passive: true },
+      );
       btt.addEventListener("click", () => window.scrollTo({ top: 0, behavior: "smooth" }));
     </script>
 


### PR DESCRIPTION
## Summary
Two-part fix for the format-drift problem surfaced during #63 → #65:

1. **Format normalization** — `npm run format` rewritten on `index.html` so `npm run check` passes against `main`.
2. **CI enforcement** — new `.github/workflows/format.yml` runs `npm run check` on every push to `main` and every pull request, so future drift is caught at CI rather than discovered by an unrelated bug-fix PR.
3. **README note** — one sentence under the Development section pointing at the new workflow.

Closes #64

## Commit structure
The branch is intentionally split so reviewers can scroll past the format churn:

| Commit | What | Why review-worthy |
| --- | --- | --- |
| `1026094` — `chore(format): apply Prettier to index.html` | 1370 lines of whitespace + line-wrap changes, no logic changes | Skim only — auto-generated by Prettier |
| `ef65e43` — `ci: enforce prettier --check on push and pull_request` | New `.github/workflows/format.yml` (25 lines) + 1-sentence README addition | This is the actual review surface |

## Workflow design choices
```yaml
on:
  push:
    branches: [main]
  pull_request:
```
- Push trigger is restricted to `main` so feature-branch pushes don't double-trigger (the PR event already covers them).
- Pull-request trigger is unrestricted so it fires for every PR regardless of base.

```yaml
- uses: actions/checkout@v4
- uses: actions/setup-node@v4
  with:
    node-version: lts/*
- run: npm install
- run: npm run check
```
- `actions/checkout@v4` and `actions/setup-node@v4` pinned to major-version tags — appropriate for a personal portfolio site (full SHA-pinning is overkill at this risk tier).
- `node-version: lts/*` matches the README's "any LTS version" guidance.
- **No `cache: npm`** and **`npm install` (not `npm ci`)** — the repo deliberately ships without a committed `package-lock.json` (see `.gitignore:21-22`). Both options require a committed lockfile, so they were dropped. Re-introduce both if `package-lock.json` is ever committed.

## Test plan
- [ ] CI green on this PR (the workflow itself runs against this PR — meta-validation).
- [ ] After merge, push a commit to `main` and confirm the workflow fires once on push.
- [ ] Open a follow-up PR with a deliberate format error and confirm CI fails red.
- [ ] No regression on the live site (format-only change to `index.html` — no behavior touched).

## Note
The `index.html` diff in commit 1 looks scary (1370 lines) but is **purely whitespace and line-wrap reformatting**. Prettier was given full latitude to satisfy `.prettierrc`. The two commits are deliberately split so a reviewer can `git diff ef65e43~1..ef65e43` to see only the load-bearing changes (workflow + README).

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*