### PR TITLE
fix: update siege-web link to glitchwerks org

### DIFF
--- a/index.html
+++ b/index.html
@@ -1591,7 +1591,7 @@
               ><span>Docker</span><span>Discord</span><span>Azure</span>
             </div>
             <div class="project-links">
-              <a href="https://github.com/cbeaulieu-gt/siege-web" target="_blank" rel="noopener"
+              <a href="https://github.com/glitchwerks/siege-web" target="_blank" rel="noopener"
                 >GitHub →</a
               >
               <a href="https://rslsiege.com" target="_blank" rel="noopener">Live site →</a>


### PR DESCRIPTION
## Summary
The `siege-web` repo was transferred from `cbeaulieu-gt` to the `glitchwerks` org. GitHub auto-redirects the old URL, but the public-facing portfolio should reflect the current owner without relying on a redirect.

Closes #62

## Diff
```diff
-              <a href="https://github.com/cbeaulieu-gt/siege-web" target="_blank" rel="noopener"
+              <a href="https://github.com/glitchwerks/siege-web" target="_blank" rel="noopener"
```

One line changed. `npm run check` passes locally.

## Verification before merge
- `gh api repos/glitchwerks/siege-web` confirms the repo lives at the new owner.
- `gh api repos/cbeaulieu-gt/siege-web` returns the same repo (GitHub redirects), so existing inbound links continue to work — this PR is about cosmetic accuracy, not unblocking traffic.

## Test plan
- [ ] CI green (Prettier check on the new workflow from #66).
- [ ] After merge, click the GitHub link on the deployed `siege-web` project card and confirm it lands on `https://github.com/glitchwerks/siege-web` directly with no redirect hop in the address bar.

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*