### PR TITLE
chore: update RSL Siege Manager link to renamed repo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1591,7 +1591,7 @@
               ><span>Docker</span><span>Discord</span><span>Azure</span>
             </div>
             <div class="project-links">
-              <a href="https://github.com/glitchwerks/siege-web" target="_blank" rel="noopener"
+              <a href="https://github.com/glitchwerks/rsl-siege-manager" target="_blank" rel="noopener"
                 >GitHub →</a
               >
               <a href="https://rslsiege.com" target="_blank" rel="noopener">Live site →</a>

--- a/index.html
+++ b/index.html
@@ -1591,7 +1591,10 @@
               ><span>Docker</span><span>Discord</span><span>Azure</span>
             </div>
             <div class="project-links">
-              <a href="https://github.com/glitchwerks/rsl-siege-manager" target="_blank" rel="noopener"
+              <a
+                href="https://github.com/glitchwerks/rsl-siege-manager"
+                target="_blank"
+                rel="noopener"
                 >GitHub →</a
               >
               <a href="https://rslsiege.com" target="_blank" rel="noopener">Live site →</a>


### PR DESCRIPTION
## Summary

Updates the GitHub link on the RSL Siege Manager portfolio entry from the old repo name (`glitchwerks/siege-web`) to the new one (`glitchwerks/rsl-siege-manager`). The upstream rename happened to align the GitHub identity with the in-app branding ("RSL Siege Manager") and the live-site domain (rslsiege.com).

GitHub's permanent redirect kept the old link working, so this is cleanup — not a broken-link fix.

## Diff

`index.html` line 1594 only:

```diff
-              <a href="https://github.com/glitchwerks/siege-web" target="_blank" rel="noopener"
+              <a href="https://github.com/glitchwerks/rsl-siege-manager" target="_blank" rel="noopener"
```

## Out of scope

- The visible "RSL Siege Manager" project name (line 1577) was already correct.
- The descriptive prose (line 1581) was untouched.
- The `https://rslsiege.com` live-site link (line 1597) is independent of the GitHub rename.

Closes #68

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_