### PR TITLE
feat: add HackerRank Orchestrate result to Support Triage Agent card

### DIFF
--- a/index.html
+++ b/index.html
@@ -1635,11 +1635,12 @@
             <div class="project-head">
               <span class="arrow">▸</span>
               <span class="project-name">Support Triage Agent</span>
-              <span class="project-kind">Hackathon · Judging</span>
+              <span class="project-kind">Hackathon · Judged</span>
             </div>
             <p class="project-blurb">
               A terminal-based AI agent that triages support tickets across HackerRank, Claude, and
-              Visa product corpora. Built solo for HackerRank Orchestrate (May 2026, 24 hrs).
+              Visa product corpora. Built solo for HackerRank Orchestrate (May 2026, 24 hrs); judged
+              65th of 12,885 participants across 1,349 submissions.
             </p>
             <p class="project-details">
               Nine-stage RAG pipeline — preprocess → safety → router → query expansion → classifier


### PR DESCRIPTION
Updates the Support Triage Agent portfolio card with the final HackerRank Orchestrate hackathon result.

## Changes

- Project-kind label: `Hackathon · Judging` → `Hackathon · Judged`
- Blurb: appended placement — 65th of 12,885 participants across 1,349 submissions

Closes #70

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_